### PR TITLE
fix(api): address code review findings for Apple webhook

### DIFF
--- a/api/src/auth/schemas.ts
+++ b/api/src/auth/schemas.ts
@@ -225,14 +225,19 @@ export const appleWebhookSchema = {
   tags: ['webhooks'],
   summary: 'Apple webhook',
   response: {
-    // Always return 200 to Apple regardless of outcome (idempotent, Apple retries on non-2xx)
+    // Returns 200 for valid JWTs regardless of business-logic outcome
+    // (idempotent — Apple retries on non-2xx, so only reject clearly invalid requests)
     200: {
       type: 'object',
       required: ['ok'],
       additionalProperties: false,
       properties: { ok: { type: 'boolean' } },
     },
+    // 400: valid JWT but malformed/missing events claim structure
+    400: errorResponse,
     // 401: invalid JWT signature, expired, wrong issuer/audience
     401: errorResponse,
+    // 500: unexpected server error (e.g. DB failure in withTransaction)
+    500: errorResponse,
   },
 } as const

--- a/api/src/auth/webhooks.test.ts
+++ b/api/src/auth/webhooks.test.ts
@@ -49,7 +49,6 @@ vi.mock('../config.js', () => ({
     secureCookies: false,
     cookieSecret: 'test-cookie-secret-32-bytes-long!!',
     nodeEnv: 'test',
-    logLevel: 'silent',
     database: { url: 'postgresql://test:test@localhost:5432/testdb' },
     jwt: {
       privateKey: testPrivatePem,
@@ -407,7 +406,7 @@ describe('Apple webhook — POST /auth/webhooks/apple', () => {
 
   // ── Malformed events claim ───────────────────────────────────────────────
 
-  it('should return 401 for malformed events JSON', async () => {
+  it('should return 400 for malformed events JSON', async () => {
     const jwt = await signTestJWT({
       events: 'not-valid-json{{{',
       iss: 'https://appleid.apple.com',
@@ -420,13 +419,13 @@ describe('Apple webhook — POST /auth/webhooks/apple', () => {
       payload: jwt,
     })
 
-    expect(response.statusCode).toBe(401)
+    expect(response.statusCode).toBe(400)
     expect(response.json<{ error: string }>().error).toBe('Malformed events claim')
   })
 
   // ── Missing events claim ─────────────────────────────────────────────────
 
-  it('should return 401 for missing events claim', async () => {
+  it('should return 400 for missing events claim', async () => {
     const key = testPrivateKey
     const jwt = await new SignJWT({})
       .setProtectedHeader({ alg: 'ES256' })
@@ -442,13 +441,13 @@ describe('Apple webhook — POST /auth/webhooks/apple', () => {
       payload: jwt,
     })
 
-    expect(response.statusCode).toBe(401)
+    expect(response.statusCode).toBe(400)
     expect(response.json<{ error: string }>().error).toBe('Missing events claim')
   })
 
   // ── Invalid events structure ─────────────────────────────────────────────
 
-  it('should return 401 for events missing type or sub', async () => {
+  it('should return 400 for events missing type or sub', async () => {
     const jwt = await signTestJWT({
       events: JSON.stringify({ type: 'consent-revoked' }), // missing sub
       iss: 'https://appleid.apple.com',
@@ -461,7 +460,7 @@ describe('Apple webhook — POST /auth/webhooks/apple', () => {
       payload: jwt,
     })
 
-    expect(response.statusCode).toBe(401)
+    expect(response.statusCode).toBe(400)
     expect(response.json<{ error: string }>().error).toBe('Invalid events structure')
   })
 
@@ -492,10 +491,12 @@ describe('Apple webhook — POST /auth/webhooks/apple', () => {
 
   // ── Non-fatal audit log failure (consent-revoked) ────────────────────────
 
-  it('should return 200 even when audit log fails for consent-revoked', async () => {
+  it('should return 200 and log.error when audit log fails for consent-revoked', async () => {
     mockTx()
     vi.mocked(queries.findOAuthAccount).mockResolvedValue(mockAppleOAuthAccount)
     vi.mocked(queries.logAuthEvent).mockRejectedValue(new Error('DB audit log write failed'))
+
+    const errorSpy = vi.spyOn(server.log, 'error')
 
     const jwt = await buildConsentRevokedJWT()
 
@@ -512,14 +513,24 @@ describe('Apple webhook — POST /auth/webhooks/apple', () => {
       expect.anything(),
       mockAppleOAuthAccount.user_id,
     )
+    // Security event must use log.error, not log.warn
+    expect(errorSpy).toHaveBeenCalledWith(
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- expect.any() returns an asymmetric matcher typed as any by vitest internals
+      expect.objectContaining({ err: expect.any(Error) }),
+      expect.stringContaining('audit log failed for consent_revoked'),
+    )
+
+    errorSpy.mockRestore()
   })
 
   // ── Non-fatal audit log failure (account-delete) ─────────────────────────
 
-  it('should return 200 even when audit log fails for account-delete', async () => {
+  it('should return 200 and log.error when audit log fails for account-delete', async () => {
     mockTx()
     vi.mocked(queries.findOAuthAccount).mockResolvedValue(mockAppleOAuthAccount)
     vi.mocked(queries.logAuthEvent).mockRejectedValue(new Error('DB audit log write failed'))
+
+    const errorSpy = vi.spyOn(server.log, 'error')
 
     const jwt = await buildAccountDeleteJWT()
 
@@ -540,6 +551,14 @@ describe('Apple webhook — POST /auth/webhooks/apple', () => {
       expect.anything(),
       mockAppleOAuthAccount.user_id,
     )
+    // Security event must use log.error, not log.warn
+    expect(errorSpy).toHaveBeenCalledWith(
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- expect.any() returns an asymmetric matcher typed as any by vitest internals
+      expect.objectContaining({ err: expect.any(Error) }),
+      expect.stringContaining('audit log failed for account_deactivated'),
+    )
+
+    errorSpy.mockRestore()
   })
 
   // ── Empty payload ────────────────────────────────────────────────────────

--- a/api/src/auth/webhooks.ts
+++ b/api/src/auth/webhooks.ts
@@ -101,7 +101,7 @@ export async function appleWebhookRoute(fastify: FastifyInstance, _opts: object)
       const eventsClaim = payload.events
       if (typeof eventsClaim !== 'string') {
         request.log.debug({ payload }, 'Apple webhook missing events claim')
-        return reply.code(401).send({ error: 'Missing events claim' })
+        return reply.code(400).send({ error: 'Missing events claim' })
       }
 
       let parsedEvent: unknown
@@ -109,12 +109,12 @@ export async function appleWebhookRoute(fastify: FastifyInstance, _opts: object)
         parsedEvent = JSON.parse(eventsClaim)
       } catch {
         request.log.debug({ eventsClaim }, 'Apple webhook malformed events JSON')
-        return reply.code(401).send({ error: 'Malformed events claim' })
+        return reply.code(400).send({ error: 'Malformed events claim' })
       }
 
       if (!isAppleEventPayload(parsedEvent)) {
         request.log.debug({ parsedEvent }, 'Apple webhook invalid events structure')
-        return reply.code(401).send({ error: 'Invalid events structure' })
+        return reply.code(400).send({ error: 'Invalid events structure' })
       }
 
       const { type: eventType, sub: providerUserId } = parsedEvent
@@ -141,7 +141,7 @@ export async function appleWebhookRoute(fastify: FastifyInstance, _opts: object)
               metadata: { provider: 'apple', apple_event_type: eventType },
             })
           } catch (auditErr) {
-            request.log.error({ err: auditErr }, 'audit log failed for consent_revoked — revocation will commit')
+            fastify.log.error({ err: auditErr }, 'audit log failed for consent_revoked — revocation will commit')
           }
         } else if (eventType === 'account-delete') {
           await queries.deactivateUser(client, userId)
@@ -155,7 +155,7 @@ export async function appleWebhookRoute(fastify: FastifyInstance, _opts: object)
               metadata: { provider: 'apple', apple_event_type: eventType },
             })
           } catch (auditErr) {
-            request.log.error({ err: auditErr }, 'audit log failed for account_deactivated — deactivation will commit')
+            fastify.log.error({ err: auditErr }, 'audit log failed for account_deactivated — deactivation will commit')
           }
         } else {
           request.log.debug({ eventType, providerUserId }, 'Apple webhook: unknown event type, ignoring')

--- a/api/src/db/queries.test.ts
+++ b/api/src/db/queries.test.ts
@@ -38,6 +38,7 @@ import {
   deleteOrphanUser,
   revokeRefreshToken,
   revokeAllUserRefreshTokens,
+  deactivateUser,
   logAuthEvent,
   toUserResponse,
   type QueryOnlyClient,
@@ -285,6 +286,30 @@ describe('queries', () => {
 
       const result = await getUserStatus(client, 'nonexistent')
       expect(result).toBe('not_found')
+    })
+  })
+
+  describe('deactivateUser', () => {
+    it('should issue UPDATE with deactivated_at = NOW() and WHERE deactivated_at IS NULL', async () => {
+      // safe: mockResolvedValue is typed for the query's return shape
+      vi.mocked(client.query).mockResolvedValue(mockQueryResult<pg.QueryResultRow>([], 1))
+
+      await deactivateUser(client, 'user-1')
+
+      expect(client.query).toHaveBeenCalledOnce()
+      const [sql, params] = vi.mocked(client.query).mock.calls[0]!
+      expect(sql).toContain('UPDATE users SET deactivated_at = NOW()')
+      expect(sql).toContain('WHERE id = $1 AND deactivated_at IS NULL')
+      expect(params).toEqual(['user-1'])
+    })
+
+    it('should be a no-op for already deactivated users (no error thrown)', async () => {
+      // Zero rows affected — user already deactivated
+      // safe: mockResolvedValue is typed for the query's return shape
+      vi.mocked(client.query).mockResolvedValue(mockQueryResult<pg.QueryResultRow>([], 0))
+
+      await expect(deactivateUser(client, 'user-already-deactivated')).resolves.toBeUndefined()
+      expect(client.query).toHaveBeenCalledOnce()
     })
   })
 


### PR DESCRIPTION
## Summary

- Fix HTTP status codes for post-JWT-verification failures: 401 → 400 (payload structure errors, not credential failures)
- Add missing `400` and `500` response entries to `appleWebhookSchema` for bidirectional schema accuracy
- Add `log.error` assertions to audit log failure tests and align audit catch blocks with `routes.ts` pattern (`fastify.log.error` instead of `request.log.error`)
- Add `deactivateUser` unit tests to `queries.test.ts`
- Fix misleading "always return 200" schema comment

## Test plan

- [x] All 377 API tests pass (including 2 new `deactivateUser` unit tests)
- [x] ESLint passes with zero warnings
- [x] TypeScript build clean
- [x] Audit log failure tests now assert `log.error` is called (matching `routes.test.ts` pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)