### PR TITLE
test(web): add Gherkin test scenarios and update E2E titles

### DIFF
--- a/docs/test-scenarios/E2E_AUTHENTICATION.md
+++ b/docs/test-scenarios/E2E_AUTHENTICATION.md
@@ -1,0 +1,24 @@
+# E2E: Authentication — Login Page
+
+## Background
+
+Given the web app is running
+And the user is on the login page (`/login`)
+
+## Scenarios
+
+### Login Page: Renders Branding and Sign-In Options
+
+```gherkin
+Scenario: Login page displays heading and Apple sign-in button
+  Given the user navigates to /login
+  Then the "Track'em Toys" heading is visible
+  And the "Sign in with Apple" button is visible
+```
+
+**Spec:** `web/e2e/login-page.spec.ts`
+
+### Notes
+
+- Google sign-in renders in a cross-origin iframe controlled by Google — Playwright cannot assert its presence reliably. Only the Apple button is verified.
+- OAuth flows themselves cannot be E2E tested (see `docs/decisions/ADR_Integration_Testing_Strategy.md` — OAuth Constraint section). Auth seeding via mocked endpoints is used instead.

--- a/docs/test-scenarios/E2E_PROTECTED_ROUTES.md
+++ b/docs/test-scenarios/E2E_PROTECTED_ROUTES.md
@@ -1,0 +1,44 @@
+# E2E: Protected Routes
+
+## Background
+
+Given the web app is running
+And all routes except `/login` require authentication
+
+## Scenarios
+
+### Guard: Unauthenticated User Redirected
+
+```gherkin
+Scenario: Unauthenticated user is redirected to /login
+  Given the user is not signed in
+  When they navigate to the home page (/)
+  Then they are redirected to /login
+```
+
+### Guard: Redirect Parameter Preserved
+
+```gherkin
+Scenario: Original URL is preserved as redirect parameter
+  Given the user is not signed in
+  When they navigate to the home page (/)
+  Then they are redirected to /login
+  And the URL contains a redirect= parameter with the original path
+```
+
+### Happy Path: Authenticated User Accesses Dashboard
+
+```gherkin
+Scenario: Authenticated user accesses the dashboard directly
+  Given the user has a valid session
+  When they navigate to the home page (/)
+  Then the "Your Collection" heading is visible
+  And the URL remains /
+```
+
+**Spec:** `web/e2e/protected-routes.spec.ts`
+
+### Notes
+
+- Auth seeding uses `setupAuthenticated()` from `web/e2e/fixtures/auth.ts`, which mocks the refresh endpoint and populates localStorage/sessionStorage via `addInitScript`.
+- The redirect parameter is set by the `_authenticated` layout guard when redirecting unauthenticated users.

--- a/docs/test-scenarios/E2E_SESSION.md
+++ b/docs/test-scenarios/E2E_SESSION.md
@@ -1,0 +1,61 @@
+# E2E: Session Management
+
+## Background
+
+Given the web app is running
+And the user has an authenticated session (seeded via `setupAuthenticated()`)
+
+## Scenarios
+
+### Happy Path: Dashboard Shows User Identity
+
+```gherkin
+Scenario: Authenticated user sees dashboard with their name
+  Given the user has a valid session
+  When they navigate to the home page
+  Then the "Your Collection" heading is visible
+  And the user's display name is shown in the UI
+```
+
+### Sign Out: Redirects and Clears Session
+
+```gherkin
+Scenario: User signs out successfully
+  Given the user is on the dashboard
+  When they click the "Sign Out" button
+  Then they are redirected to /login
+  And the session flag is removed from localStorage
+```
+
+### Persistence: Session Survives Page Reload
+
+```gherkin
+Scenario: Session persists across page reload
+  Given the user is on the dashboard
+  When they reload the page
+  Then the refresh token endpoint is called
+  And the dashboard is displayed again with "Your Collection" heading
+```
+
+### Expiry: Expired Refresh Token Clears Session
+
+```gherkin
+Scenario: Expired refresh token redirects to login
+  Given the user is on the dashboard
+  And the refresh token has expired (server returns 401)
+  When they reload the page
+  Then AuthProvider detects the failed refresh
+  And the user is redirected to /login
+  And the session flag is removed from localStorage
+```
+
+**Specs:**
+- `web/e2e/authenticated-session.spec.ts` — Dashboard identity, sign out
+- `web/e2e/session-persistence.spec.ts` — Reload survival, expired refresh
+
+### Notes
+
+- Session seeding uses `addInitScript` to populate `localStorage` and `sessionStorage` before React mounts. This ensures `AuthProvider.init()` finds the session flag synchronously on mount.
+- The expired refresh scenario replaces the mock mid-test using `page.unrouteAll()` + `mockRefreshFailure()` to simulate server-side token expiry.
+- `localStorage` key: `trackem:has_session` (boolean flag)
+- `sessionStorage` key: `trackem:user` (JSON user profile)

--- a/docs/test-scenarios/README.md
+++ b/docs/test-scenarios/README.md
@@ -15,9 +15,9 @@ See [TESTING_SCENARIOS.md](../guides/TESTING_SCENARIOS.md) for the scenario-driv
 
 | Scenario Document | Spec File | Status |
 |---|---|---|
-| _No scenarios yet_ | — | — |
-
-> **Existing tests:** The E2E specs in `web/e2e/` and API tests in `api/src/` were written before this convention was adopted. Scenario documents for those tests can be added retroactively if useful, but are not required.
+| [E2E_AUTHENTICATION.md](E2E_AUTHENTICATION.md) | `web/e2e/login-page.spec.ts` | ✅ Implemented |
+| [E2E_PROTECTED_ROUTES.md](E2E_PROTECTED_ROUTES.md) | `web/e2e/protected-routes.spec.ts` | ✅ Implemented |
+| [E2E_SESSION.md](E2E_SESSION.md) | `web/e2e/authenticated-session.spec.ts`, `web/e2e/session-persistence.spec.ts` | ✅ Implemented |
 
 ## Creating a New Scenario
 

--- a/web/e2e/authenticated-session.spec.ts
+++ b/web/e2e/authenticated-session.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 import { setupAuthenticated, validUser } from './fixtures/auth'
 
 test.describe('Authenticated session', () => {
-  test('authenticated user sees dashboard with collection heading and user name', async ({ page }) => {
+  test('Given valid session, When navigating to /, Then dashboard shows collection heading and user name', async ({ page }) => {
     await setupAuthenticated(page)
     await page.goto('/')
 
@@ -10,7 +10,16 @@ test.describe('Authenticated session', () => {
     await expect(page.getByText(validUser.display_name!)).toBeVisible()
   })
 
-  test('sign out redirects to /login and clears session flag', async ({ page }) => {
+  /**
+   * ```gherkin
+   * Scenario: User signs out successfully
+   *   Given the user is on the dashboard
+   *   When they click the "Sign Out" button
+   *   Then they are redirected to /login
+   *   And the session flag is removed from localStorage
+   * ```
+   */
+  test('Given user on dashboard, When clicking sign out, Then redirected to /login and session cleared', async ({ page }) => {
     await setupAuthenticated(page)
     await page.goto('/')
 

--- a/web/e2e/login-page.spec.ts
+++ b/web/e2e/login-page.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test'
 
 test.describe('Login page', () => {
-  test('renders heading and Apple sign-in button', async ({ page }) => {
+  test('Given user navigates to /login, Then heading and Apple sign-in button are visible', async ({ page }) => {
     await page.goto('/login')
 
     await expect(page.getByRole('heading', { name: /Track.em Toys/i })).toBeVisible()

--- a/web/e2e/protected-routes.spec.ts
+++ b/web/e2e/protected-routes.spec.ts
@@ -2,12 +2,12 @@ import { test, expect } from '@playwright/test'
 import { setupAuthenticated } from './fixtures/auth'
 
 test.describe('Protected routes', () => {
-  test('unauthenticated user redirected to /login', async ({ page }) => {
+  test('Given unauthenticated user, When navigating to /, Then redirected to /login', async ({ page }) => {
     await page.goto('/')
     await expect(page).toHaveURL(/\/login/)
   })
 
-  test('redirect param preserved in URL', async ({ page }) => {
+  test('Given unauthenticated user, When navigating to /, Then redirect param preserves original URL', async ({ page }) => {
     // Visit a protected path — should redirect to /login with redirect param
     await page.goto('/')
     await expect(page).toHaveURL(/\/login/)
@@ -15,7 +15,7 @@ test.describe('Protected routes', () => {
     await expect(page).toHaveURL(/redirect=/)
   })
 
-  test('authenticated user accesses dashboard directly', async ({ page }) => {
+  test('Given authenticated user, When navigating to /, Then dashboard is displayed', async ({ page }) => {
     await setupAuthenticated(page)
     await page.goto('/')
 

--- a/web/e2e/session-persistence.spec.ts
+++ b/web/e2e/session-persistence.spec.ts
@@ -2,7 +2,16 @@ import { test, expect } from '@playwright/test'
 import { setupAuthenticated, mockRefreshFailure } from './fixtures/auth'
 
 test.describe('Session persistence', () => {
-  test('session survives page reload (refresh called again, dashboard shows)', async ({ page }) => {
+  /**
+   * ```gherkin
+   * Scenario: Session persists across page reload
+   *   Given the user is on the dashboard
+   *   When they reload the page
+   *   Then the refresh token endpoint is called
+   *   And the dashboard is displayed again with "Your Collection" heading
+   * ```
+   */
+  test('Given user on dashboard, When page is reloaded, Then session persists and dashboard shows', async ({ page }) => {
     await setupAuthenticated(page)
     await page.goto('/')
 
@@ -14,7 +23,18 @@ test.describe('Session persistence', () => {
     await expect(page.getByRole('heading', { name: /your collection/i })).toBeVisible()
   })
 
-  test('session lost when refresh token expired (401 → redirected to login)', async ({ page }) => {
+  /**
+   * ```gherkin
+   * Scenario: Expired refresh token redirects to login
+   *   Given the user is on the dashboard
+   *   And the refresh token has expired (server returns 401)
+   *   When they reload the page
+   *   Then AuthProvider detects the failed refresh
+   *   And the user is redirected to /login
+   *   And the session flag is removed from localStorage
+   * ```
+   */
+  test('Given expired refresh token, When page is reloaded, Then redirected to /login and session cleared', async ({ page }) => {
     await setupAuthenticated(page)
     await page.goto('/')
 

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -7,7 +7,11 @@ import { TanStackRouterVite } from '@tanstack/router-plugin/vite'
 
 export default defineConfig({
   plugins: [
-    TanStackRouterVite({ target: 'react', autoCodeSplitting: true }),
+    TanStackRouterVite({
+      target: 'react',
+      autoCodeSplitting: true,
+      routeFileIgnorePattern: '__tests__',
+    }),
     tailwindcss(),
     react(),
   ],


### PR DESCRIPTION
## Summary

- Create 3 Gherkin scenario documents for authentication E2E tests (`E2E_AUTHENTICATION.md`, `E2E_PROTECTED_ROUTES.md`, `E2E_SESSION.md`)
- Update all 8 E2E test titles to Given/When/Then format
- Add JSDoc Gherkin scenarios to 3 complex multi-step tests
- Populate scenario-to-spec mapping table in `docs/test-scenarios/README.md`
- Add `routeFileIgnorePattern: '__tests__'` to TanStack Router config to suppress route warnings for test files

Closes #18

## Test plan

- [x] All 8 E2E tests pass (`cd web && npm run test:e2e`) — 8 passed (3.3s)
- [x] No TanStack Router warnings about test files in route tree
- [x] Verify scenario doc cross-references resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)