### PR TITLE
test(api): seed ingestion integration tests and backfill changelogs

### DIFF
--- a/api/src/db/seed-integration.test.ts
+++ b/api/src/db/seed-integration.test.ts
@@ -1,0 +1,406 @@
+/**
+ * Seed data integration tests — runs the seed ingestion script against a real
+ * PostgreSQL database and verifies the seeded data is correct.
+ *
+ * Requires a running PostgreSQL instance with migrations applied.
+ * Skipped automatically when DATABASE_URL is not set.
+ *
+ * Companion to seed-validation.test.ts (static JSON checks, no DB).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { execSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+import pg from 'pg'
+
+// ─── Constants ──────────────────────────────────────────────────────────────
+
+const DB_URL = process.env['DATABASE_URL']
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const API_DIR = path.resolve(__dirname, '../../')
+
+const CATALOG_TABLES = [
+  'continuity_families', 'factions', 'sub_groups', 'manufacturers',
+  'toy_lines', 'characters', 'character_sub_groups',
+  'character_appearances', 'items',
+] as const
+type CatalogTable = typeof CATALOG_TABLES[number]
+
+const SLUG_TABLES: CatalogTable[] = [
+  'continuity_families', 'factions', 'sub_groups', 'manufacturers',
+  'toy_lines', 'characters', 'character_appearances', 'items',
+]
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+// Commands are hardcoded literals — no user input, no injection risk.
+// execSync is used intentionally to run the CLI script as it would in production.
+
+function runSeed(npmScript: 'seed' | 'seed:purge'): void {
+  try {
+    execSync(`npm run ${npmScript}`, {
+      cwd: API_DIR,
+      env: { ...process.env },
+      stdio: 'pipe',
+    })
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException & { stdout?: Buffer; stderr?: Buffer }
+    throw new Error(
+      `${npmScript} failed:\n${e.stderr?.toString() ?? ''}\n${e.stdout?.toString() ?? ''}`,
+      { cause: err },
+    )
+  }
+}
+
+async function queryCount(pool: pg.Pool, table: CatalogTable): Promise<number> {
+  const { rows } = await pool.query<{ count: string }>(
+    `SELECT COUNT(*) AS count FROM ${table}`,
+  )
+  return Number(rows[0]!.count)
+}
+
+async function queryOrphanedFKs(
+  pool: pg.Pool,
+  childTable: CatalogTable,
+  childCol: string,
+  parentTable: CatalogTable,
+): Promise<string[]> {
+  // For junction table character_sub_groups (no slug column), return character_id::text
+  const identCol = childTable === 'character_sub_groups' ? `c.${childCol}::text` : 'c.slug'
+  const { rows } = await pool.query<{ slug: string }>(
+    `SELECT ${identCol} AS slug
+     FROM ${childTable} c
+     LEFT JOIN ${parentTable} p ON c.${childCol} = p.id
+     WHERE c.${childCol} IS NOT NULL AND p.id IS NULL`,
+  )
+  return rows.map((r) => r.slug)
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe.skipIf(!DB_URL)('seed integration', () => {
+  let pool: pg.Pool
+
+  // ── 0. Setup & teardown ─────────────────────────────────────────────────
+
+  beforeAll(() => {
+    pool = new pg.Pool({ connectionString: DB_URL!, max: 2 })
+    runSeed('seed:purge')
+  }, 90_000)
+
+  afterAll(async () => {
+    await pool.query(
+      `TRUNCATE items, character_appearances, character_sub_groups,
+               characters, toy_lines, manufacturers,
+               sub_groups, factions, continuity_families
+       CASCADE`,
+    )
+    await pool.end()
+  })
+
+  // ── 1. Row counts ──────────────────────────────────────────────────────
+
+  describe('row counts', () => {
+    it.each([
+      { table: 'continuity_families' as CatalogTable, expected: 10 },
+      { table: 'factions' as CatalogTable, expected: 11 },
+      { table: 'sub_groups' as CatalogTable, expected: 52 },
+      { table: 'manufacturers' as CatalogTable, expected: 3 },
+      { table: 'toy_lines' as CatalogTable, expected: 16 },
+    ])('$table has $expected rows (reference)', async ({ table, expected }) => {
+      const count = await queryCount(pool, table)
+      expect(count, `${table} row count`).toBe(expected)
+    })
+
+    it.each([
+      { table: 'characters' as CatalogTable, expected: 440 },
+      { table: 'character_sub_groups' as CatalogTable, expected: 328 },
+      { table: 'character_appearances' as CatalogTable, expected: 508 },
+      { table: 'items' as CatalogTable, expected: 395 },
+    ])('$table has $expected rows (entities)', async ({ table, expected }) => {
+      const count = await queryCount(pool, table)
+      expect(count, `${table} row count`).toBe(expected)
+    })
+  })
+
+  // ── 2. No duplicate slugs ─────────────────────────────────────────────
+
+  describe('no duplicate slugs', () => {
+    it.each(SLUG_TABLES.map((t) => ({ table: t })))(
+      '$table has no duplicate slugs',
+      async ({ table }) => {
+        const { rows } = await pool.query<{ slug: string; cnt: string }>(
+          `SELECT slug, COUNT(*) AS cnt FROM ${table} GROUP BY slug HAVING COUNT(*) > 1`,
+        )
+        expect(rows, `${table}: found duplicate slugs: ${rows.map((r) => r.slug).join(', ')}`).toHaveLength(0)
+      },
+    )
+  })
+
+  // ── 3. FK referential integrity ───────────────────────────────────────
+
+  describe('FK referential integrity', () => {
+    it('sub_groups.faction_id → factions', async () => {
+      expect(await queryOrphanedFKs(pool, 'sub_groups', 'faction_id', 'factions')).toEqual([])
+    })
+
+    it('toy_lines.manufacturer_id → manufacturers', async () => {
+      expect(await queryOrphanedFKs(pool, 'toy_lines', 'manufacturer_id', 'manufacturers')).toEqual([])
+    })
+
+    it('characters.faction_id → factions', async () => {
+      expect(await queryOrphanedFKs(pool, 'characters', 'faction_id', 'factions')).toEqual([])
+    })
+
+    it('characters.continuity_family_id → continuity_families', async () => {
+      expect(await queryOrphanedFKs(pool, 'characters', 'continuity_family_id', 'continuity_families')).toEqual([])
+    })
+
+    it('characters.combined_form_id → characters (self-ref)', async () => {
+      expect(await queryOrphanedFKs(pool, 'characters', 'combined_form_id', 'characters')).toEqual([])
+    })
+
+    it('character_sub_groups.character_id → characters', async () => {
+      expect(await queryOrphanedFKs(pool, 'character_sub_groups', 'character_id', 'characters')).toEqual([])
+    })
+
+    it('character_sub_groups.sub_group_id → sub_groups', async () => {
+      expect(await queryOrphanedFKs(pool, 'character_sub_groups', 'sub_group_id', 'sub_groups')).toEqual([])
+    })
+
+    it('character_appearances.character_id → characters', async () => {
+      expect(await queryOrphanedFKs(pool, 'character_appearances', 'character_id', 'characters')).toEqual([])
+    })
+
+    it('items.manufacturer_id → manufacturers', async () => {
+      expect(await queryOrphanedFKs(pool, 'items', 'manufacturer_id', 'manufacturers')).toEqual([])
+    })
+
+    it('items.toy_line_id → toy_lines', async () => {
+      expect(await queryOrphanedFKs(pool, 'items', 'toy_line_id', 'toy_lines')).toEqual([])
+    })
+
+    it('items.character_id → characters', async () => {
+      expect(await queryOrphanedFKs(pool, 'items', 'character_id', 'characters')).toEqual([])
+    })
+
+    it('items.character_appearance_id → character_appearances', async () => {
+      expect(await queryOrphanedFKs(pool, 'items', 'character_appearance_id', 'character_appearances')).toEqual([])
+    })
+  })
+
+  // ── 4. Combiner relationships ─────────────────────────────────────────
+
+  describe('combiner relationships', () => {
+    it('Devastator has exactly 6 Constructicon components', async () => {
+      const { rows } = await pool.query<{ slug: string }>(
+        `SELECT c.slug FROM characters c
+         JOIN characters form ON form.id = c.combined_form_id
+         WHERE form.slug = 'devastator'
+         ORDER BY c.slug`,
+      )
+      expect(rows.map((r) => r.slug)).toEqual([
+        'bonecrusher', 'hook', 'long-haul', 'mixmaster', 'scavenger', 'scrapper',
+      ])
+    })
+
+    it.each([
+      { combiner: 'superion', expected: 5 },
+      { combiner: 'menasor', expected: 5 },
+      { combiner: 'bruticus', expected: 5 },
+      { combiner: 'defensor', expected: 5 },
+    ])('$combiner has $expected components', async ({ combiner, expected }) => {
+      const { rows } = await pool.query<{ count: string }>(
+        `SELECT COUNT(*) AS count FROM characters c
+         JOIN characters form ON form.id = c.combined_form_id
+         WHERE form.slug = $1`,
+        [combiner],
+      )
+      expect(Number(rows[0]!.count), `${combiner} component count`).toBe(expected)
+    })
+
+    it('all combined_form_id targets have is_combined_form = true', async () => {
+      const { rows } = await pool.query<{ slug: string }>(
+        `SELECT DISTINCT form.slug FROM characters c
+         JOIN characters form ON form.id = c.combined_form_id
+         WHERE form.is_combined_form = false`,
+      )
+      expect(
+        rows,
+        `Characters referenced as combined forms but with is_combined_form=false: ${rows.map((r) => r.slug).join(', ')}`,
+      ).toHaveLength(0)
+    })
+  })
+
+  // ── 5. Junction table: character_sub_groups ───────────────────────────
+
+  describe('junction table: character_sub_groups', () => {
+    it('Apeface belongs to both headmasters and horrorcons', async () => {
+      const { rows } = await pool.query<{ slug: string }>(
+        `SELECT sg.slug FROM character_sub_groups csg
+         JOIN characters c ON c.id = csg.character_id
+         JOIN sub_groups sg ON sg.id = csg.sub_group_id
+         WHERE c.slug = 'apeface'
+         ORDER BY sg.slug`,
+      )
+      const slugs = rows.map((r) => r.slug)
+      expect(slugs).toContain('headmasters')
+      expect(slugs).toContain('horrorcons')
+    })
+
+    it('no orphaned junction rows', async () => {
+      const { rows } = await pool.query<{ count: string }>(
+        `SELECT COUNT(*) AS count FROM character_sub_groups csg
+         LEFT JOIN characters c ON c.id = csg.character_id
+         LEFT JOIN sub_groups sg ON sg.id = csg.sub_group_id
+         WHERE c.id IS NULL OR sg.id IS NULL`,
+      )
+      expect(Number(rows[0]!.count)).toBe(0)
+    })
+  })
+
+  // ── 6. Item data correctness ──────────────────────────────────────────
+
+  describe('item data correctness', () => {
+    it('FansToys items: all have is_third_party = true', async () => {
+      const { rows } = await pool.query<{ count: string }>(
+        `SELECT COUNT(*) AS count FROM items i
+         JOIN manufacturers m ON m.id = i.manufacturer_id
+         WHERE m.slug = 'fanstoys' AND i.is_third_party = false`,
+      )
+      expect(Number(rows[0]!.count), 'FansToys items with is_third_party=false').toBe(0)
+    })
+
+    it('FansToys item count is 118', async () => {
+      const { rows } = await pool.query<{ count: string }>(
+        `SELECT COUNT(*) AS count FROM items i
+         JOIN manufacturers m ON m.id = i.manufacturer_id
+         WHERE m.slug = 'fanstoys'`,
+      )
+      expect(Number(rows[0]!.count)).toBe(118)
+    })
+
+    it('Hasbro items: all have is_third_party = false', async () => {
+      const { rows } = await pool.query<{ count: string }>(
+        `SELECT COUNT(*) AS count FROM items i
+         JOIN manufacturers m ON m.id = i.manufacturer_id
+         WHERE m.slug = 'hasbro' AND i.is_third_party = true`,
+      )
+      expect(Number(rows[0]!.count), 'Hasbro items with is_third_party=true').toBe(0)
+    })
+
+    it('Hasbro item count is 277', async () => {
+      const { rows } = await pool.query<{ count: string }>(
+        `SELECT COUNT(*) AS count FROM items i
+         JOIN manufacturers m ON m.id = i.manufacturer_id
+         WHERE m.slug = 'hasbro'`,
+      )
+      expect(Number(rows[0]!.count)).toBe(277)
+    })
+
+    it('FT-01 MP-1 Trailer has correct fields', async () => {
+      const { rows } = await pool.query<{
+        slug: string
+        is_third_party: boolean
+        year_released: number
+        size_class: string
+        manufacturer_slug: string
+        character_slug: string
+        metadata: Record<string, unknown>
+      }>(
+        `SELECT i.slug, i.is_third_party, i.year_released, i.size_class,
+                m.slug AS manufacturer_slug, c.slug AS character_slug,
+                i.metadata
+         FROM items i
+         JOIN manufacturers m ON m.id = i.manufacturer_id
+         JOIN characters c ON c.id = i.character_id
+         WHERE i.slug = 'ft-01-mp-1-trailer'`,
+      )
+      expect(rows).toHaveLength(1)
+      const item = rows[0]!
+      expect(item.is_third_party).toBe(true)
+      expect(item.year_released).toBe(2006)
+      expect(item.size_class).toBe('Masterpiece')
+      expect(item.manufacturer_slug).toBe('fanstoys')
+      expect(item.character_slug).toBe('optimus-prime')
+      expect(item.metadata).toHaveProperty('status')
+      expect(item.metadata).toHaveProperty('sub_brand')
+    })
+
+    it('Hasbro Bumblebee (05701) has correct fields', async () => {
+      const { rows } = await pool.query<{
+        slug: string
+        is_third_party: boolean
+        year_released: number
+        manufacturer_slug: string
+        character_slug: string
+      }>(
+        `SELECT i.slug, i.is_third_party, i.year_released,
+                m.slug AS manufacturer_slug, c.slug AS character_slug
+         FROM items i
+         JOIN manufacturers m ON m.id = i.manufacturer_id
+         JOIN characters c ON c.id = i.character_id
+         WHERE i.slug = '05701-bumblebee'`,
+      )
+      expect(rows).toHaveLength(1)
+      const item = rows[0]!
+      expect(item.is_third_party).toBe(false)
+      expect(item.year_released).toBe(1984)
+      expect(item.manufacturer_slug).toBe('hasbro')
+      expect(item.character_slug).toBe('bumblebee')
+    })
+
+    it('items with character_slug optimus-prime have valid character_id', async () => {
+      const { rows } = await pool.query<{ count: string }>(
+        `SELECT COUNT(*) AS count FROM items i
+         JOIN characters c ON c.id = i.character_id
+         WHERE c.slug = 'optimus-prime'`,
+      )
+      expect(Number(rows[0]!.count)).toBeGreaterThan(0)
+    })
+  })
+
+  // ── 7. Idempotency ────────────────────────────────────────────────────
+
+  describe('idempotency', () => {
+    it('purge + re-seed produces identical row counts', async () => {
+      // Capture counts from the initial seed (already run in beforeAll)
+      const countsBefore: Record<string, number> = {}
+      for (const table of CATALOG_TABLES) {
+        countsBefore[table] = await queryCount(pool, table)
+      }
+      expect(countsBefore['characters'], 'precondition: DB must have seed data').toBeGreaterThan(0)
+
+      // Run purge + re-seed (seed:purge does TRUNCATE then full seed in one transaction)
+      runSeed('seed:purge')
+
+      // Verify counts are identical
+      const countsAfter: Record<string, number> = {}
+      for (const table of CATALOG_TABLES) {
+        countsAfter[table] = await queryCount(pool, table)
+      }
+
+      expect(countsAfter).toEqual(countsBefore)
+    }, 90_000)
+
+    it('upsert mode (no purge) produces identical row counts', async () => {
+      const countsBefore: Record<string, number> = {}
+      for (const table of CATALOG_TABLES) {
+        countsBefore[table] = await queryCount(pool, table)
+      }
+      expect(countsBefore['characters'], 'precondition: DB must have seed data').toBeGreaterThan(0)
+
+      // Run upsert mode (no --purge)
+      runSeed('seed')
+
+      const countsAfter: Record<string, number> = {}
+      for (const table of CATALOG_TABLES) {
+        countsAfter[table] = await queryCount(pool, table)
+      }
+
+      expect(countsAfter).toEqual(countsBefore)
+    }, 90_000)
+  })
+})

--- a/changelog/2026-03-03T230708_interactive-api-docs-swagger-scalar.md
+++ b/changelog/2026-03-03T230708_interactive-api-docs-swagger-scalar.md
@@ -1,0 +1,139 @@
+# Interactive API Documentation with Swagger and Scalar
+
+**Date:** 2026-03-03
+**Time:** 23:07:08 -0800
+**Type:** Infrastructure
+**Phase:** 1.2 (API Auth)
+**Version:** v0.2.5
+
+## Summary
+
+Added auto-generated OpenAPI 3.0 documentation and an interactive API reference UI powered by `@fastify/swagger` and `@scalar/fastify-api-reference`. The docs plugin is gated to non-production environments and serves an interactive explorer at `/reference/`. All 6 existing route schemas were enriched with descriptions, tags, summaries, and security metadata.
+
+---
+
+## Changes Implemented
+
+### 1. Docs Plugin
+
+Created a Fastify plugin that registers Swagger (OpenAPI spec generation) and Scalar (interactive reference UI).
+
+**Created:**
+- `api/src/plugins/docs.ts` — Plugin using `fastify-plugin` wrapper that registers:
+  - `@fastify/swagger` — Generates OpenAPI 3.0.3 spec from Fastify route schemas
+  - `@scalar/fastify-api-reference` — Serves interactive API explorer at `/reference/`
+  - Defines three API tags: `system`, `jwks`, `auth`
+  - Declares `bearerAuth` security scheme (HTTP Bearer with JWT format)
+
+### 2. Server Integration
+
+Registered the docs plugin in `buildServer()`, gated behind an environment check so it's excluded in production.
+
+**Modified:**
+- `api/src/server.ts` — Conditionally registers `docsPlugin` when `nodeEnv !== 'production'`
+
+### 3. Schema Enrichment
+
+Enhanced all existing route schemas with OpenAPI metadata for better documentation.
+
+**Modified:**
+- `api/src/auth/schemas.ts` — Added `description`, `summary`, `tags`, and `security` fields to all 6 route schemas (signin, refresh, logout, link-account, JWKS, health)
+- `api/src/auth/jwks.ts` — Added schema metadata for the JWKS discovery endpoint
+
+### 4. Dependencies
+
+**Added:**
+- `@fastify/swagger` — OpenAPI spec generation from Fastify schemas
+- `@scalar/fastify-api-reference` — Modern API reference UI (alternative to Swagger UI)
+
+**Modified:**
+- `api/package.json` — Added 2 new dependencies
+- `api/package-lock.json` — Lock file updated (+277 lines)
+
+---
+
+## Technical Details
+
+### OpenAPI Spec Configuration
+
+```typescript
+openapi: {
+  openapi: '3.0.3',
+  info: {
+    title: "Track'em Toys API",
+    version: '0.1.0',
+  },
+  tags: [
+    { name: 'system', description: 'Health and status endpoints' },
+    { name: 'jwks', description: 'JSON Web Key Set discovery' },
+    { name: 'auth', description: 'Authentication and session management' },
+  ],
+  components: {
+    securitySchemes: {
+      bearerAuth: { type: 'http', scheme: 'bearer', bearerFormat: 'JWT' },
+    },
+  },
+}
+```
+
+### Environment Gating
+
+The docs plugin is only registered when `config.nodeEnv !== 'production'`, keeping the OpenAPI spec and reference UI inaccessible in production deployments. This is a defense-in-depth measure — the spec itself isn't secret, but exposing a full API explorer in production is unnecessary attack surface.
+
+### Test Strategy
+
+Tests use `vi.doMock()` + `vi.resetModules()` to swap `config.nodeEnv` between describe blocks, giving each suite a fresh `buildServer()` import that sees the correct environment. This verifies both that docs are served in development and that they are absent in production.
+
+---
+
+## Validation & Testing
+
+**Created:**
+- `api/src/plugins/docs.test.ts` — 158 lines covering:
+  - OpenAPI spec generation (`/documentation/json` returns valid spec)
+  - Scalar reference UI serves at `/reference/`
+  - Route schemas appear with correct tags and descriptions
+  - Production environment excludes docs routes (404)
+  - Security scheme declaration in spec output
+
+---
+
+## Impact Assessment
+
+- **Developer experience**: Developers can explore and test all API endpoints interactively at `https://localhost:3010/reference/`
+- **Schema quality**: Enriching route schemas with descriptions and tags improves both documentation and validation error messages
+- **Production safety**: Environment gating ensures no documentation leakage in production
+- **Future routes**: All new routes automatically appear in the docs when they define Fastify schemas
+
+---
+
+## Related Files
+
+**Created (2):**
+- `api/src/plugins/docs.ts`
+- `api/src/plugins/docs.test.ts`
+
+**Modified (4):**
+- `api/src/server.ts`
+- `api/src/auth/schemas.ts`
+- `api/src/auth/jwks.ts`
+- `api/package.json`
+
+---
+
+## Summary Statistics
+
+| Metric | Count |
+|--------|-------|
+| Files created | 2 |
+| Files modified | 4 |
+| Lines added | ~504 |
+| Dependencies added | 2 |
+| Route schemas enriched | 6 |
+| Test lines added | 158 |
+
+---
+
+## Status
+
+✅ COMPLETE

--- a/changelog/2026-03-04T150203_account-settings-and-link-account.md
+++ b/changelog/2026-03-04T150203_account-settings-and-link-account.md
@@ -1,0 +1,178 @@
+# Account Settings UI with GET /auth/me and Link-Account Flow
+
+**Date:** 2026-03-04
+**Time:** 15:02:03 -0800
+**Type:** Feature
+**Phase:** 1.2 (API Auth) / 1.3 (Web SPA Auth)
+**Version:** v0.3.0
+
+## Summary
+
+Added the `GET /auth/me` endpoint returning the authenticated user's profile with linked OAuth accounts, and built account settings pages on both web (React + TanStack Query) and iOS (SwiftUI). Also fixed a production bug where `linked_accounts` was always empty due to a `pg` driver type mismatch in the OAuth row type guard.
+
+---
+
+## Changes Implemented
+
+### 1. GET /auth/me API Endpoint
+
+New authenticated endpoint returning the current user's profile and linked OAuth providers.
+
+**Route:** `GET /auth/me`
+- Returns user profile fields plus a `linked_accounts` array (provider + email per account)
+- Uses `fastify.authenticate` preHandler and rate-limited to 20 req/min
+- Calls `findUserWithAccounts` to JOIN users with oauth_accounts in a single query
+- Returns 401 if the JWT `sub` is invalid or the user is not found
+
+**Modified:**
+- `api/src/auth/routes.ts` — Added `/me` route handler
+- `api/src/auth/schemas.ts` — Added `meSchema` with response JSON Schema
+
+**Tests added:**
+- `api/src/auth/routes.test.ts` — 108 lines of new test coverage for the `/me` endpoint
+
+### 2. Web Settings Page
+
+Full account settings page built with React, TanStack Query, and Shadcn/ui components.
+
+**Created:**
+- `web/src/auth/SettingsPage.tsx` — Settings page showing user profile, role badge, linked accounts, and link-account buttons
+- `web/src/auth/hooks/useMe.ts` — TanStack Query hook wrapping `GET /auth/me`
+- `web/src/auth/hooks/useLinkAccount.ts` — Mutation hook for linking additional OAuth providers
+- `web/src/components/ui/badge.tsx` — Shadcn Badge component
+- `web/src/components/ui/card.tsx` — Shadcn Card component
+- `web/src/routes/_authenticated/settings.tsx` — TanStack Router route for `/settings`
+
+**Modified:**
+- `web/src/routes/_authenticated/index.tsx` — Added navigation link to settings
+- `web/src/routeTree.gen.ts` — Auto-regenerated route tree
+- `web/eslint.config.js` — Minor rule adjustment
+
+**Tests added:**
+- `web/src/auth/__tests__/SettingsPage.test.tsx` — 294 lines covering rendering, loading states, error states, and link-account interactions
+- `web/src/auth/hooks/__tests__/useMe.test.ts` — Hook unit tests
+- `web/src/auth/hooks/__tests__/useLinkAccount.test.ts` — Mutation hook unit tests
+
+### 3. iOS Settings Screen
+
+SwiftUI account settings view with linked account display and sign-in integration.
+
+**Created:**
+- `ios/track-em-toys/Settings/AccountSettingsView.swift` — SwiftUI view showing profile info, linked providers, and link-account buttons
+- `ios/track-em-toys/Networking/AuthEndpoints.swift` — `GET /auth/me` API client
+- `ios/track-em-toys/Networking/NetworkModels.swift` — Response models for the me endpoint
+
+**Modified:**
+- `ios/track-em-toys/App/TrackEmToysApp.swift` — Added settings navigation
+- `ios/track-em-toys/Auth/AuthManager.swift` — Added account linking methods
+
+**Tests added:**
+- `ios/track-em-toysTests/Auth/AuthManagerTests.swift` — 23 lines for account linking
+- `ios/track-em-toysTests/Networking/AuthEndpointsTests.swift` — 84 lines for endpoint construction
+- `ios/track-em-toysTests/Networking/NetworkModelsTests.swift` — 93 lines for model decoding
+
+### 4. Bug Fix: Empty linked_accounts in Production
+
+Fixed a bug where `isCompleteOAuthRow` in `api/src/db/queries.ts` checked `typeof oa_created_at === 'string'`, but the `pg` driver returns `TIMESTAMPTZ` columns as JavaScript `Date` objects — not strings. This caused the type guard to always return `false`, making `linked_accounts` an empty array even when OAuth accounts existed.
+
+**Fix:** Widened the type from `string` to `Date | string` and replaced `typeof oa_created_at === 'string'` with `oa_created_at != null`.
+
+**Modified:**
+- `api/src/db/queries.ts` — Fixed `UserWithAccountsRow` type and `isCompleteOAuthRow` type guard
+- `api/src/db/queries.test.ts` — Updated tests to reflect corrected types
+
+---
+
+## Technical Details
+
+### GET /auth/me Response Shape
+
+```json
+{
+  "id": "uuid",
+  "email": "user@example.com",
+  "display_name": "User Name",
+  "role": "user",
+  "linked_accounts": [
+    { "provider": "apple", "email": "user@privaterelay.appleid.com" },
+    { "provider": "google", "email": "user@gmail.com" }
+  ]
+}
+```
+
+### pg Driver TIMESTAMPTZ Behavior
+
+The `pg` driver auto-parses `TIMESTAMPTZ` columns into JavaScript `Date` objects by default (type OID 1184). Code that checks `typeof column === 'string'` against these values will always fail at runtime, even though TypeScript's structural typing may not catch the mismatch at compile time if the type is declared as `string`.
+
+---
+
+## Validation & Testing
+
+| Module | Tests Added | Coverage |
+|--------|-------------|----------|
+| API (`routes.test.ts`) | +108 lines | `/me` happy path, 401 unauthorized, user not found |
+| API (`queries.test.ts`) | +8 lines | Type guard fix verification |
+| Web (`SettingsPage.test.tsx`) | +294 lines | Render, loading, error, link-account interactions |
+| Web (`useMe.test.ts`) | +53 lines | Query hook unit tests |
+| Web (`useLinkAccount.test.ts`) | +75 lines | Mutation hook unit tests |
+| iOS (`AuthManagerTests`) | +23 lines | Account linking |
+| iOS (`AuthEndpointsTests`) | +84 lines | Endpoint construction |
+| iOS (`NetworkModelsTests`) | +93 lines | Model decoding |
+
+---
+
+## Impact Assessment
+
+- **Cross-module feature**: One of the first features touching all three modules (api, web, ios) in a single PR
+- **User-facing**: Users can now view their profile, see which OAuth providers are linked, and link additional providers
+- **Bug fix**: Resolves an issue where linked accounts were invisible despite existing in the database
+- **UI components**: Introduced Shadcn Badge and Card components, reusable across future web pages
+
+---
+
+## Related Files
+
+**Created (12):**
+- `api/src/auth/routes.test.ts` (new test coverage)
+- `web/src/auth/SettingsPage.tsx`
+- `web/src/auth/__tests__/SettingsPage.test.tsx`
+- `web/src/auth/hooks/useMe.ts`
+- `web/src/auth/hooks/__tests__/useMe.test.ts`
+- `web/src/auth/hooks/useLinkAccount.ts`
+- `web/src/auth/hooks/__tests__/useLinkAccount.test.ts`
+- `web/src/components/ui/badge.tsx`
+- `web/src/components/ui/card.tsx`
+- `web/src/routes/_authenticated/settings.tsx`
+- `ios/track-em-toys/Settings/AccountSettingsView.swift`
+- `ios/track-em-toys/Networking/AuthEndpoints.swift`
+- `ios/track-em-toys/Networking/NetworkModels.swift`
+
+**Modified (8):**
+- `api/src/auth/routes.ts`
+- `api/src/auth/schemas.ts`
+- `api/src/db/queries.ts`
+- `api/src/db/queries.test.ts`
+- `api/src/types/index.ts`
+- `ios/track-em-toys/App/TrackEmToysApp.swift`
+- `ios/track-em-toys/Auth/AuthManager.swift`
+- `web/src/routes/_authenticated/index.tsx`
+
+---
+
+## Summary Statistics
+
+| Metric | Count |
+|--------|-------|
+| Files created | 12 |
+| Files modified | 8 |
+| Lines added | ~1,526 |
+| Lines removed | ~46 |
+| Modules touched | 3 (api, web, ios) |
+| Bugs fixed | 1 (pg TIMESTAMPTZ type guard) |
+| UI components added | 2 (Badge, Card) |
+
+---
+
+## Status
+
+✅ COMPLETE

--- a/changelog/2026-03-16T104524_fanstoys-slug-fks-and-item-validation.md
+++ b/changelog/2026-03-16T104524_fanstoys-slug-fks-and-item-validation.md
@@ -1,0 +1,152 @@
+# FansToys Slug-Based FKs and Item Validation Tests
+
+**Date:** 2026-03-16
+**Time:** 10:45:24 -0700
+**Type:** Feature / Configuration
+**Phase:** 1.4 (Catalog Schema/Seed)
+**Version:** v0.4.0
+
+## Summary
+
+Converted all 118 FansToys seed items from integer ID references to slug-based foreign key convention (`manufacturer_slug`, `toy_line_slug`, `character_slug`), removed denormalized fields, and moved ancillary data into a `metadata` JSONB object. Added Guardian Robot to `g1-season1.json` to resolve an unresolved character reference. Extended the seed validation test suite with item-specific checks covering FK integrity, slug format, duplicates, required fields, and legacy integer ID detection.
+
+---
+
+## Changes Implemented
+
+### 1. FansToys Seed Data Migration to Slug-Based FKs
+
+Rewrote all 118 item entries in the FansToys seed file to follow the project's slug-based FK convention.
+
+**Before (integer IDs):**
+```json
+{
+  "manufacturer_id": 1,
+  "toy_line_id": 104,
+  "character_faction_id": 2,
+  "character_sub_group_id": 5,
+  "status": "released",
+  "variant_type": null
+}
+```
+
+**After (slug-based FKs):**
+```json
+{
+  "manufacturer_slug": "fanstoys",
+  "toy_line_slug": "fanstoys-mainline",
+  "character_slug": "optimus-prime",
+  "metadata": {
+    "status": "released",
+    "variant_type": null,
+    "sub_brand": null,
+    "notes": null
+  }
+}
+```
+
+**Changes applied to each item:**
+- `manufacturer_id` → `manufacturer_slug`
+- `toy_line_id` → `toy_line_slug`
+- Removed `character_faction_id` and `character_sub_group_id` (denormalized convenience fields — canonical source is the characters table)
+- Moved `status`, `variant_type`, `sub_brand`, `notes` into `metadata` JSONB
+- Updated `_metadata` import instructions to reflect the slug resolution workflow
+
+**Modified:**
+- `api/db/seed/manufacturers/fanstoys/fanstoys.json` — Full rewrite of 118 items (+2,133 / −2,250 lines from format changes)
+
+### 2. Guardian Robot Character Addition
+
+Added Guardian Robot to the G1 Season 1 character file to resolve an unresolved `character_slug` reference from the FT-20G item.
+
+**Modified:**
+- `api/db/seed/characters/g1-season1.json` — Added Guardian Robot character entry (+22 lines)
+
+### 3. Item Seed Validation Tests
+
+Extended the existing seed validation test suite with a new `item seed files` section covering 7 validation checks.
+
+**Tests added:**
+| Test | Purpose |
+|------|---------|
+| `_metadata.total_items matches items array length` | Catches metadata/data drift |
+| `slug format valid` | Enforces lowercase-kebab-case convention |
+| `no duplicate item slugs` | Prevents duplicate entries within a file |
+| `manufacturer_slug resolves to manufacturers` | FK integrity check |
+| `toy_line_slug resolves to toy_lines` | FK integrity check |
+| `character_slug resolves to characters` | FK integrity check |
+| `required item fields present` | Structural validation |
+| `no integer ID fields (must use slugs)` | Guardrail against regression to old convention |
+
+**Modified:**
+- `api/src/db/seed-validation.test.ts` — Added `ItemRecord`/`ItemFile` interfaces, `loadItemFile` loader, derived lookup sets, and 8 test cases (+135 lines)
+
+---
+
+## Technical Details
+
+### Why Slug-Based FKs Over Integer IDs
+
+Integer ID references in seed data create fragile positional coupling:
+- They depend on insertion order — reseeding or adding a row shifts all downstream IDs
+- They're opaque in code review — `"manufacturer_id": 1` conveys no meaning
+- They break when migrating between environments with different seed histories
+
+Slug-based references are stable, human-readable, and insertion-order-independent. The seed ingestion script resolves slugs to UUIDs at import time via `WHERE slug = $1` lookups.
+
+### Legacy Integer ID Detection
+
+The test `no integer ID fields (must use slugs)` explicitly checks that none of the legacy fields (`manufacturer_id`, `toy_line_id`, `character_id`, `character_faction_id`, `character_sub_group_id`) exist on any item. This acts as a compile-time-equivalent guardrail: if anyone re-introduces integer IDs, the test suite fails immediately.
+
+### Metadata JSONB Pattern
+
+Fields like `status`, `variant_type`, `sub_brand`, and `notes` are item-level attributes that don't warrant dedicated columns in the early schema. Storing them in a `metadata` JSONB field keeps the core `items` table lean while preserving the data for future use. They can be promoted to proper columns if query patterns demand it.
+
+---
+
+## Validation & Testing
+
+498 tests passing after changes.
+
+**New test coverage (+135 lines):**
+- 8 parameterized test cases via `it.each(itemFiles)` covering all item seed files
+- FK integrity checks cross-reference against loaded manufacturer, toy line, and character seed data
+- Duplicate detection uses a `Set` accumulator per file
+
+---
+
+## Impact Assessment
+
+- **Seed data convention**: Establishes slug-based FKs as the standard for all item seed files going forward — enforced by tests
+- **Data integrity**: FK integrity checks catch broken references before they reach the database
+- **Character completeness**: Adding Guardian Robot fills a gap in the G1 character catalog
+- **Future seed files**: The test framework automatically validates any new item files added to the `ITEM_FILES` array
+
+---
+
+## Related Files
+
+**Modified (3):**
+- `api/db/seed/manufacturers/fanstoys/fanstoys.json`
+- `api/db/seed/characters/g1-season1.json`
+- `api/src/db/seed-validation.test.ts`
+
+---
+
+## Summary Statistics
+
+| Metric | Count |
+|--------|-------|
+| Files modified | 3 |
+| Lines added | ~1,226 |
+| Lines removed | ~1,203 |
+| Items converted | 118 |
+| Validation tests added | 8 |
+| Total tests passing | 498 |
+| Characters added | 1 (Guardian Robot) |
+
+---
+
+## Status
+
+✅ COMPLETE

--- a/changelog/2026-03-16T111000_ml-accelerated-roadmap-and-decisions.md
+++ b/changelog/2026-03-16T111000_ml-accelerated-roadmap-and-decisions.md
@@ -1,0 +1,135 @@
+# ML-Accelerated Development Roadmap and Architectural Decisions
+
+**Date:** 2026-03-16
+**Time:** 11:10:00 -0700
+**Type:** Documentation Standards
+**Phase:** 1.4 (Catalog Schema/Seed)
+**Version:** v0.4.0
+
+## Summary
+
+Formalized the ML-accelerated development roadmap with a web-first strategy that prioritizes photo identification over collection management. Documented 7 key architectural decisions and updated all module-level CLAUDE.md files with new conventions for roles, photo domains, and development strategy. Added GitHub issue templates for standardized project tracking.
+
+---
+
+## Changes Implemented
+
+### 1. Development Roadmap
+
+Authored the full development roadmap (`docs/plans/Development_Roadmap_v1_0.md`) defining the ML-first phase sequence: 1.4 (Seed) → 1.5 (Catalog API) → 1.5b (Roles) → 1.9 (Photos) → 4.0 (ML) → 2.0 (iOS). This reorders the original plan to deliver ML-powered toy identification before building out collection management features.
+
+**Created:**
+- `docs/plans/Development_Roadmap_v1_0.md` — 759-line roadmap with phase definitions, dependencies, and milestones
+
+### 2. Architectural Decision Records
+
+Documented 7 architectural decisions covering the project's core design choices.
+
+**Created:**
+- `docs/decisions/2026-03-16_roadmap_session_decisions.md` — Captures decisions on:
+  1. ML-accelerated web-first development path
+  2. OAuth-only authentication (no email/password)
+  3. Two photo domains (catalog shared vs user private)
+  4. User roles model (user / curator / admin)
+  5. Hybrid admin approach (web admin + iOS curator)
+  6. GDPR account deletion via tombstone pattern
+  7. GitHub project tracking strategy
+
+**Modified:**
+- `docs/decisions/Schema_Design_Rationale.md` — Added rationale for roles and photo privacy schema design
+
+### 3. CLAUDE.md Convention Updates
+
+Updated all module-level instruction files to reflect the new architectural decisions, ensuring Claude agents follow the ML-first strategy and role/photo conventions.
+
+**Modified:**
+- `CLAUDE.md` — Added development strategy, photo domains, user roles, and security guidelines sections
+- `api/CLAUDE.md` — Added role middleware patterns and catalog photo conventions
+- `web/CLAUDE.md` — Added admin route conventions and role-based UI patterns
+- `ios/CLAUDE.md` — Added deferred-to-post-ML notes and CloudKit sync strategy
+- `ml/CLAUDE.md` — Added Core ML conventions and catalog photo training notes
+
+### 4. GitHub Issue Templates
+
+Added structured issue templates to standardize how features, bugs, and tasks are created.
+
+**Created:**
+- `.github/ISSUE_TEMPLATE/feature.yml` — Feature template with phase dropdown and module selector
+- `.github/ISSUE_TEMPLATE/bug.yml` — Bug report template with reproduction steps
+- `.github/ISSUE_TEMPLATE/task.yml` — Task template with acceptance criteria
+- `.github/ISSUE_TEMPLATE/config.yml` — Template chooser configuration
+
+### 5. Test Scenario Scaffolding
+
+Added planned test scenario entries and doc gate guidance for future phases.
+
+**Modified:**
+- `docs/test-scenarios/README.md` — Added scenario mapping entries for upcoming phases
+- `docs/guides/DOC_GATE_REFERENCE.md` — Added guidance notes
+
+---
+
+## Technical Details
+
+### Roadmap Phase Reordering
+
+The original roadmap followed a linear feature-build approach (schema → API → iOS → ML). The ML-accelerated reordering front-loads the photo pipeline and ML training so that by the time iOS ships, the app launches with its headline feature (snap-to-identify) rather than adding it as a later update.
+
+### Role Model Design
+
+Three roles with additive permissions:
+- `user` — browse catalog, manage own collection
+- `curator` — user powers + catalog write operations (items, photos, edits)
+- `admin` — curator powers + user management, role assignment
+
+Role is embedded in JWT claims to avoid per-request DB lookups.
+
+---
+
+## Impact Assessment
+
+- **Development direction**: All subsequent work follows the ML-first phase ordering
+- **Agent behavior**: Updated CLAUDE.md files ensure Claude agents understand roles, photo domains, and development strategy
+- **Project tracking**: Issue templates standardize how work items are created across the team
+
+---
+
+## Related Files
+
+**Created (7):**
+- `docs/plans/Development_Roadmap_v1_0.md`
+- `docs/decisions/2026-03-16_roadmap_session_decisions.md`
+- `.github/ISSUE_TEMPLATE/feature.yml`
+- `.github/ISSUE_TEMPLATE/bug.yml`
+- `.github/ISSUE_TEMPLATE/task.yml`
+- `.github/ISSUE_TEMPLATE/config.yml`
+- `docs/decisions/Research_for_Toy_Collection_Catalog_and_Pricing_App.md` (minor addition)
+
+**Modified (8):**
+- `CLAUDE.md`
+- `api/CLAUDE.md`
+- `web/CLAUDE.md`
+- `ios/CLAUDE.md`
+- `ml/CLAUDE.md`
+- `docs/decisions/Schema_Design_Rationale.md`
+- `docs/test-scenarios/README.md`
+- `docs/guides/DOC_GATE_REFERENCE.md`
+
+---
+
+## Summary Statistics
+
+| Metric | Count |
+|--------|-------|
+| Files created | 7 |
+| Files modified | 8 |
+| Lines added | ~1,109 |
+| Architectural decisions documented | 7 |
+| Issue templates added | 3 (+1 config) |
+| CLAUDE.md files updated | 5 |
+
+---
+
+## Status
+
+✅ COMPLETE

--- a/changelog/2026-03-17T110641_hasbro-g1-items-seed-ingestion-skill.md
+++ b/changelog/2026-03-17T110641_hasbro-g1-items-seed-ingestion-skill.md
@@ -1,0 +1,234 @@
+# Hasbro G1 Items, Seed Ingestion, and Research-Catalog Skill
+
+**Date:** 2026-03-17
+**Time:** 11:06:41 -0700
+**Type:** Feature
+**Phase:** 1.4 (Catalog Schema/Seed)
+**Version:** v0.4.1
+
+## Summary
+
+Major catalog data expansion: consolidated G1 character files into a single 439-character file, added 439 character appearances spanning all G1 continuities, seeded 277 Hasbro G1 items (1984–1990) with verified product codes, and built the seed ingestion script (`ingest.ts`) that resolves slug-based FK references to UUIDs and upserts everything into PostgreSQL. Also added migration 014 (source_media CHECK constraint), created the research-catalog Claude skill, and extracted CLAUDE.md rules into dedicated `.claude/rules/` files.
+
+---
+
+## Changes Implemented
+
+### 1. G1 Character Consolidation
+
+Merged 10 per-season/per-source character files into a single `g1-characters.json` with 439 characters. This simplifies the seed directory structure and eliminates cross-file duplication.
+
+**Created:**
+- `api/db/seed/characters/g1-characters.json` — 439 characters across NA cartoon, toy-only, JP Headmasters, Masterforce, Victory, and Zone (7,132 lines)
+
+**Deleted (10 files):**
+- `api/db/seed/characters/g1-season1.json`
+- `api/db/seed/characters/g1-season2.json`
+- `api/db/seed/characters/g1-season3.json`
+- `api/db/seed/characters/g1-season4.json`
+- `api/db/seed/characters/g1-movie.json`
+- `api/db/seed/characters/g1-toy-only.json`
+- `api/db/seed/characters/jp-headmasters.json`
+- `api/db/seed/characters/jp-masterforce.json`
+- `api/db/seed/characters/jp-victory.json`
+- `api/db/seed/characters/jp-zone.json`
+
+Notable additions:
+- **Jetfire** — split from Skyfire as a separate character (cartoon vs Macross-licensed toy are distinct entities in the collector market)
+- **Guardian Robot** — previously missing, referenced by FansToys FT-20G
+
+### 2. G1 Character Appearances
+
+Created `g1-appearances.json` with 439+ appearances providing 1:1 character coverage across all G1 media sources, plus specialized toy-deco appearances.
+
+**Created:**
+- `api/db/seed/appearances/g1-appearances.json` — 5,596 lines covering:
+  - NA cartoon appearances (TV)
+  - Toy-only characters with no media appearance
+  - JP Headmasters, Masterforce, Victory, Zone (TV)
+  - 8 G1 cartoon-divergent toy appearances (Ratchet, Ironhide, Megatron, Ultra Magnus, Swoop, Bluestreak, Galvatron)
+  - Astrotrain US/JP toy variants, RadioShack Shockwave
+  - 47 G2 redecos (released + unreleased prototypes including Stunticons and Protectobots)
+  - 11 distinctive toy liveries: Jazz (Martini), Smokescreen (#38 racing), Mirage (Gitanes F1), Wheeljack (Alitalia), Prowl (police), Hound (military), Tracks (flames), Red Alert (fire chief), Inferno (fire dept), Slag (chrome Diaclone), Bombshell (chrome Insector)
+
+### 3. Hasbro G1 Items (277 entries, 1984–1990)
+
+Seeded the complete Hasbro G1 toy line across 7 years with product codes sourced from TFArchive's Hasbro item number database.
+
+**Created:**
+- `api/db/seed/items/hasbro/g1-items.json` — 277 items (5,310 lines)
+
+**Coverage by year:**
+| Year | Count | Highlights |
+|------|-------|-----------|
+| 1984 | ~28 | Autobot Cars, Minibots, Seekers, Soundwave & Cassettes |
+| 1985 | ~40 | Dinobots, Constructicons, Insecticons, Jumpstarters, Deluxe Vehicles |
+| 1986 | ~60 | Movie heroes (Hot Rod, Ultra Magnus, Galvatron), Triple Changers, combiners, Battlechargers |
+| 1987 | ~45 | Headmasters, Targetmasters, Terrorcons, Technobots, Horrorcons, Throttlebots, Duocons, Clones, Monsterbots |
+| 1988 | ~50 | Powermasters, Pretenders (all sub-types), Double Targetmasters, Seacons, Sparkabots, Firecons, Triggerbots/Triggercons |
+| 1989 | ~35 | Classic/Mega/Ultra Pretenders, Pretender Monsters, Legends (KMart exclusives) |
+| 1990 | ~19 | Action Masters |
+
+**Flagship items:** Fortress Maximus, Scorponok, Trypticon, combiner giftsets (Predaking, Bruticus, Abominus, Piranacon)
+
+**Modeling decisions:**
+- Cassette 2-packs modeled as single items with primary character FK
+- Toy-specific appearance slugs used where toy and cartoon designs diverge
+- `character_appearance_slug` FK links each item to its specific visual representation
+
+### 4. Seed Directory Restructure
+
+Renamed `api/db/seed/manufacturers/` → `api/db/seed/items/` to better reflect content semantics (items organized by manufacturer, not manufacturer data).
+
+**Moved:**
+- `api/db/seed/manufacturers/fanstoys/fanstoys.json` → `api/db/seed/items/fanstoys/fanstoys.json` (118 items updated with `character_appearance_slug`)
+
+### 5. Seed Ingestion Script
+
+Built the complete seed-to-database pipeline that resolves slug-based FK references to UUIDs and upserts data into PostgreSQL.
+
+**Created:**
+- `api/db/seed/ingest.ts` — 695-line TypeScript script with:
+  - **Slug resolution**: `buildSlugMap()` loads all existing slugs from DB, `resolveSlug()` / `resolveOptionalSlug()` map slug strings to UUIDs at insert time
+  - **Dependency-ordered upserts**: continuity families → factions → sub-groups → manufacturers → toy lines → characters (pass 1) → character sub-groups → characters (pass 2 for cross-refs) → appearances → items
+  - **Two-pass character insert**: Pass 1 creates characters without cross-references; pass 2 back-fills leader/combiner FKs that point to other characters
+  - **Upsert semantics**: `ON CONFLICT (slug) DO UPDATE` for idempotent re-runs
+  - **Purge mode**: `--purge --confirm` truncates all catalog tables in reverse-FK order and re-seeds
+  - **Auto-discovery**: Recursively finds all `.json` files in seed subdirectories
+
+- `api/tsconfig.seed.json` — Dedicated TypeScript config for type-checking the ingest script separately from the main API
+
+**npm scripts added:**
+- `npm run seed` — Run ingest script (upsert mode)
+- `npm run seed:purge` — Truncate + re-seed (requires `--confirm`)
+- `npm run typecheck:seed` — Type-check ingest script independently
+
+### 6. Migration 014: source_media CHECK Constraint
+
+Added a database-level CHECK constraint on `character_appearances.source_media` to enforce valid values. Merged "Comic" and "Manga" into a single "Comic/Manga" value.
+
+**Created:**
+- `api/db/migrations/014_add_source_media_check.sql` — Adds CHECK constraint: `TV`, `Comic/Manga`, `Movie`, `OVA`, `Toy-only`, `Video Game`
+
+**Modified:**
+- `api/db/schema.sql` — Updated schema dump to reflect new constraint
+
+### 7. Research-Catalog Skill
+
+Created a Claude Code skill for researching Transformers toy and character data from web sources and generating seed JSON files.
+
+**Created:**
+- `.claude/skills/research-catalog/SKILL.md` — 649-line skill document covering:
+  - TFArchive as primary source for Hasbro product codes
+  - Appearance slug selection table (when to use toy vs cartoon appearance)
+  - Multi-character product handling (cassette packs, combiner giftsets)
+  - Bulk Python generation pattern for large item batches
+  - Official item naming and slug conventions
+
+### 8. CLAUDE.md Rules Extraction
+
+Extracted three behavioral rules from CLAUDE.md into dedicated `.claude/rules/` files for better enforcement by Claude Code.
+
+**Created:**
+- `.claude/rules/commit-discipline.md` — Never commit without explicit instruction
+- `.claude/rules/doc-gates-task-integration.md` — Documentation gates must appear as explicit tasks
+- `.claude/rules/gh-issues-no-auto-close.md` — Never auto-close GitHub issues
+
+**Modified:**
+- `CLAUDE.md` — Consolidated documentation accuracy section, removed rules now in dedicated files
+
+---
+
+## Technical Details
+
+### Two-Pass Character Upsert
+
+Characters can reference other characters (e.g., a combiner team's leader, or a character's combined form). This creates circular FK dependencies that can't be resolved in a single INSERT pass.
+
+**Pass 1** inserts all characters with `leader_slug` and `combined_form_slug` set to NULL, establishing the base rows and their UUIDs.
+
+**Pass 2** runs `UPDATE` statements to back-fill `leader_id` and `combined_form_id` using the now-populated slug→UUID map.
+
+### Purge Mode Safety
+
+The `--purge` flag requires `--confirm` as a second argument to prevent accidental data loss. Truncation follows reverse-FK order (items → appearances → characters → … → continuity_families) to avoid foreign key violations.
+
+### Appearance Slug Selection
+
+Items reference a specific `character_appearance_slug` to indicate which visual representation the toy depicts. This matters when a character's toy differs significantly from their cartoon/media appearance (e.g., G1 Ratchet the ambulance vs cartoon Ratchet the humanoid robot).
+
+---
+
+## Validation & Testing
+
+**Modified:**
+- `api/src/db/seed-validation.test.ts` — Updated to reflect:
+  - Consolidated character file (single `g1-characters.json` replaces 10 files)
+  - New appearance validation checks
+  - Updated item file paths (`items/` instead of `manufacturers/`)
+  - `character_appearance_slug` FK integrity checks
+  - +160 lines changed
+
+---
+
+## Impact Assessment
+
+- **Catalog completeness**: The G1 Transformers catalog now has 439 characters, 439+ appearances, and 395 items (277 Hasbro + 118 FansToys) — covering the foundational generation of the Transformers franchise
+- **Seed pipeline**: `npm run seed` provides a one-command path from JSON files to a populated PostgreSQL database, unblocking the Catalog API (Phase 1.5)
+- **Data conventions**: Appearance-level item linking establishes the pattern for how the ML photo identification system will map a toy photo to its specific visual variant
+- **Developer tooling**: The research-catalog skill codifies the research methodology, making future seed expansion (G2, Beast Wars, etc.) repeatable
+
+---
+
+## Related Files
+
+**Created (8):**
+- `api/db/seed/characters/g1-characters.json`
+- `api/db/seed/appearances/g1-appearances.json`
+- `api/db/seed/items/hasbro/g1-items.json`
+- `api/db/seed/ingest.ts`
+- `api/tsconfig.seed.json`
+- `api/db/migrations/014_add_source_media_check.sql`
+- `.claude/skills/research-catalog/SKILL.md`
+- `.claude/rules/commit-discipline.md`, `doc-gates-task-integration.md`, `gh-issues-no-auto-close.md`
+
+**Modified (5):**
+- `api/db/seed/items/fanstoys/fanstoys.json` (moved from `manufacturers/`, added appearance slugs)
+- `api/db/seed/README.md`
+- `api/db/schema.sql`
+- `api/package.json`
+- `api/src/db/seed-validation.test.ts`
+- `CLAUDE.md`
+
+**Deleted (10):**
+- `api/db/seed/characters/g1-season1.json` through `g1-season4.json`
+- `api/db/seed/characters/g1-movie.json`, `g1-toy-only.json`
+- `api/db/seed/characters/jp-headmasters.json`, `jp-masterforce.json`, `jp-victory.json`, `jp-zone.json`
+
+---
+
+## Summary Statistics
+
+| Metric | Count |
+|--------|-------|
+| Files created | 11 |
+| Files modified | 6 |
+| Files deleted | 10 |
+| Lines added | ~19,758 |
+| Lines removed | ~9,219 |
+| Net lines added | ~10,539 |
+| Characters consolidated | 439 |
+| Appearances added | 439+ |
+| Hasbro G1 items seeded | 277 |
+| FansToys items updated | 118 |
+| Total catalog items | 395 |
+| Ingestion script lines | 695 |
+| Migration added | 1 (014) |
+| npm scripts added | 3 |
+| Claude rules extracted | 3 |
+
+---
+
+## Status
+
+✅ COMPLETE

--- a/changelog/2026-03-17T115450_seed-ingestion-integration-tests.md
+++ b/changelog/2026-03-17T115450_seed-ingestion-integration-tests.md
@@ -1,0 +1,149 @@
+# Seed Ingestion Integration Tests
+
+**Date:** 2026-03-17
+**Time:** 11:54:50 -0700
+**Type:** Feature
+**Phase:** 1.4 (Catalog Schema/Seed)
+**Version:** v0.4.1
+
+## Summary
+
+Added a full integration test suite for the seed ingestion pipeline, verifying seeded data against a real PostgreSQL database. Covers row counts, slug uniqueness, FK referential integrity, combiner relationships, junction table membership, item data correctness, and idempotency. Tests skip gracefully when `DATABASE_URL` is not set. Also added the companion Gherkin test scenario document and updated the scenario mapping table.
+
+---
+
+## Changes Implemented
+
+### 1. Seed Integration Test Suite
+
+End-to-end tests that run `npm run seed:purge` against a real PostgreSQL instance and verify the resulting data.
+
+**Created:**
+- `api/src/db/seed-integration.test.ts` — 406 lines, 7 test sections
+
+| Section | Tests | What it verifies |
+|---------|-------|-----------------|
+| Row counts | 9 | Every catalog table has the expected number of rows after seed (reference tables + entities) |
+| No duplicate slugs | 8 | All slug-bearing tables have unique slugs in the database (not just in JSON) |
+| FK referential integrity | 12 | Every foreign key across all catalog tables resolves to an existing parent row |
+| Combiner relationships | 6 | Devastator has exactly 6 Constructicons; Superion, Menasor, Bruticus, Defensor each have 5; all `combined_form_id` targets have `is_combined_form = true` |
+| Junction table | 2 | Apeface belongs to both headmasters and horrorcons; no orphaned junction rows |
+| Item data correctness | 7 | FansToys items are `is_third_party = true` (118 count); Hasbro items are `is_third_party = false` (277 count); spot-checks on FT-01 and Bumblebee with field-level assertions |
+| Idempotency | 2 | Purge + re-seed produces identical row counts; upsert mode (no purge) produces identical row counts |
+
+**Key design decisions:**
+- `describe.skipIf(!DB_URL)` — entire suite skips without failure when no database is available, so local `npm test` works without PostgreSQL
+- `beforeAll` runs `seed:purge` with a 90-second timeout to accommodate cold-start seed ingestion
+- `afterAll` truncates all catalog tables to leave the database clean
+- `queryOrphanedFKs` helper uses LEFT JOIN + IS NULL pattern to detect dangling FK references, returning the slug of the offending row for clear error messages
+- Idempotency tests capture row counts before and after re-running the seed script, verifying `ON CONFLICT (slug) DO UPDATE` semantics
+
+### 2. Gherkin Test Scenario Document
+
+Written-first scenario document mapping 1:1 to the integration test cases.
+
+**Created:**
+- `docs/test-scenarios/INT_SEED_INGESTION.md` — 121 lines with 8 scenarios:
+  - Happy Path: Row Counts After Seed
+  - Integrity: No Duplicate Slugs
+  - Integrity: FK References Are Valid
+  - Domain: Combiner Relationships
+  - Domain: Junction Table Multi-Group Membership
+  - Domain: Item Data Correctness
+  - Idempotency: Re-Seed Produces Same Results
+  - Guard: Graceful Skip Without Database
+
+### 3. Scenario Mapping Table Update
+
+**Modified:**
+- `docs/test-scenarios/README.md` — Added `INT_SEED_INGESTION.md` → `api/src/db/seed-integration.test.ts` mapping row
+
+---
+
+## Technical Details
+
+### Companion to seed-validation.test.ts
+
+The project now has two complementary seed test layers:
+
+| Layer | File | What it tests | Requires DB? |
+|-------|------|--------------|-------------|
+| Static validation | `seed-validation.test.ts` | JSON structure, slug format, FK slug resolution against other JSON files, metadata counts | No |
+| Integration | `seed-integration.test.ts` | Actual database state after ingestion, SQL-level uniqueness, FK constraints, upsert idempotency | Yes |
+
+Static validation catches structural errors before they hit the database. Integration tests catch issues that only surface during actual SQL execution — constraint violations, slug collisions across files, type coercion mismatches, and upsert conflict resolution.
+
+### queryOrphanedFKs Pattern
+
+```typescript
+async function queryOrphanedFKs(
+  pool: pg.Pool,
+  childTable: CatalogTable,
+  childCol: string,
+  parentTable: CatalogTable,
+): Promise<string[]> {
+  const { rows } = await pool.query(
+    `SELECT c.slug FROM ${childTable} c
+     LEFT JOIN ${parentTable} p ON c.${childCol} = p.id
+     WHERE c.${childCol} IS NOT NULL AND p.id IS NULL`,
+  )
+  return rows.map((r) => r.slug)
+}
+```
+
+Returns an empty array on success; returns the slugs of offending rows on failure. The `IS NOT NULL` filter excludes nullable FKs that are legitimately NULL. Special-cased for `character_sub_groups` (junction table with no slug column) to return `character_id::text` instead.
+
+### Idempotency Testing Strategy
+
+Two distinct modes are tested:
+1. **Purge + re-seed** (`seed:purge`): TRUNCATEs all tables then re-inserts everything. Verifies no data drift from repeated full reloads.
+2. **Upsert mode** (`seed`): Runs `INSERT ... ON CONFLICT (slug) DO UPDATE` over existing data. Verifies no row count inflation from re-running without purge.
+
+Both tests use a before/after row count comparison across all 9 catalog tables.
+
+---
+
+## Validation & Testing
+
+The test suite itself is the validation artifact. Expected to produce 46+ test cases across 7 `describe` blocks when run against a seeded database.
+
+---
+
+## Impact Assessment
+
+- **Seed pipeline confidence**: Developers can now verify that `npm run seed:purge` produces a correct, consistent database state — not just well-formed JSON files
+- **CI integration**: Tests auto-skip without `DATABASE_URL`, so they can be conditionally enabled in CI pipelines with a PostgreSQL service container
+- **Regression detection**: Any future seed data change that breaks FK integrity, introduces slug duplicates, or changes row counts will be caught immediately
+- **Idempotency guarantee**: Confirms the ingestion script is safe to run repeatedly without data corruption
+
+---
+
+## Related Files
+
+**Created (2):**
+- `api/src/db/seed-integration.test.ts`
+- `docs/test-scenarios/INT_SEED_INGESTION.md`
+
+**Modified (1):**
+- `docs/test-scenarios/README.md`
+
+---
+
+## Summary Statistics
+
+| Metric | Count |
+|--------|-------|
+| Files created | 2 |
+| Files modified | 1 |
+| Lines added | 528 |
+| Test sections | 7 |
+| Test cases | 46+ |
+| Gherkin scenarios | 8 |
+| Tables verified | 9 |
+| FK relationships checked | 12 |
+
+---
+
+## Status
+
+✅ COMPLETE

--- a/docs/test-scenarios/INT_SEED_INGESTION.md
+++ b/docs/test-scenarios/INT_SEED_INGESTION.md
@@ -1,0 +1,121 @@
+# INT: Seed Data Ingestion
+
+## Background
+
+Given a running PostgreSQL database with all migrations applied
+And the seed JSON files exist in `api/db/seed/`
+
+## Scenarios
+
+### Happy Path: Row Counts After Seed
+
+```gherkin
+Scenario: All catalog tables have expected row counts after seed:purge
+  Given the database is empty
+  When the seed ingestion script runs with --purge --confirm
+  Then continuity_families has 10 rows
+  And factions has 11 rows
+  And sub_groups has 52 rows
+  And manufacturers has 3 rows
+  And toy_lines has 16 rows
+  And characters has 440 rows
+  And character_appearances has 508 rows
+  And items has 395 rows
+```
+
+### Integrity: No Duplicate Slugs
+
+```gherkin
+Scenario: All slug-bearing tables have unique slugs
+  Given the seed has been ingested
+  Then no table has duplicate slug values
+```
+
+### Integrity: FK References Are Valid
+
+```gherkin
+Scenario: All foreign key references resolve to existing rows
+  Given the seed has been ingested
+  Then all characters.faction_id values reference valid factions
+  And all characters.continuity_family_id values reference valid continuity_families
+  And all characters.combined_form_id values reference valid characters
+  And all character_sub_groups entries reference valid characters and sub_groups
+  And all character_appearances.character_id values reference valid characters
+  And all sub_groups.faction_id values reference valid factions
+  And all toy_lines.manufacturer_id values reference valid manufacturers
+  And all items.manufacturer_id values reference valid manufacturers
+  And all items.toy_line_id values reference valid toy_lines
+  And all items.character_id values reference valid characters
+  And all items.character_appearance_id values reference valid character_appearances
+```
+
+### Domain: Combiner Relationships
+
+```gherkin
+Scenario: Devastator has exactly 6 Constructicon components
+  Given the seed has been ingested
+  When querying characters with combined_form_id pointing to Devastator
+  Then exactly 6 components are found
+  And they are bonecrusher, hook, long-haul, mixmaster, scavenger, scrapper
+
+Scenario: Other combiners have expected component counts
+  Given the seed has been ingested
+  Then Superion has 5 components
+  And Menasor has 5 components
+  And Bruticus has 5 components
+  And Defensor has 5 components
+
+Scenario: All combined_form_id targets are marked as combined forms
+  Given the seed has been ingested
+  Then every character with a combined_form_id points to a character with is_combined_form = true
+```
+
+### Domain: Junction Table Multi-Group Membership
+
+```gherkin
+Scenario: Apeface belongs to both headmasters and horrorcons
+  Given the seed has been ingested
+  When querying character_sub_groups for Apeface
+  Then the result includes both headmasters and horrorcons sub-groups
+```
+
+### Domain: Item Data Correctness
+
+```gherkin
+Scenario: FansToys items are marked as third-party
+  Given the seed has been ingested
+  Then all items with manufacturer slug "fanstoys" have is_third_party = true
+  And the FansToys item count is 118
+
+Scenario: Hasbro items are marked as official
+  Given the seed has been ingested
+  Then all items with manufacturer slug "hasbro" have is_third_party = false
+  And the Hasbro item count is 277
+
+Scenario: FT-01 MP-1 Trailer spot-check
+  Given the seed has been ingested
+  When querying the item with slug "ft-01-mp-1-trailer"
+  Then is_third_party is true
+  And manufacturer_slug is "fanstoys"
+  And character_slug is "optimus-prime"
+  And metadata contains status and sub_brand fields
+```
+
+### Idempotency: Re-Seed Produces Same Results
+
+```gherkin
+Scenario: Purge and re-seed produces identical row counts
+  Given the seed has been ingested once
+  When the seed script runs again with --purge --confirm
+  Then all table row counts are unchanged
+  And no orphaned rows exist
+```
+
+### Guard: Graceful Skip Without Database
+
+```gherkin
+Scenario: Tests skip when DATABASE_URL is not set
+  Given DATABASE_URL is not in the environment
+  When the test suite runs
+  Then the seed integration tests are skipped without failure
+```

--- a/docs/test-scenarios/README.md
+++ b/docs/test-scenarios/README.md
@@ -18,6 +18,7 @@ See [TESTING_SCENARIOS.md](../guides/TESTING_SCENARIOS.md) for the scenario-driv
 | [E2E_AUTHENTICATION.md](E2E_AUTHENTICATION.md) | `web/e2e/login-page.spec.ts` | ✅ Implemented |
 | [E2E_PROTECTED_ROUTES.md](E2E_PROTECTED_ROUTES.md) | `web/e2e/protected-routes.spec.ts` | ✅ Implemented |
 | [E2E_SESSION.md](E2E_SESSION.md) | `web/e2e/authenticated-session.spec.ts`, `web/e2e/session-persistence.spec.ts` | ✅ Implemented |
+| [INT_SEED_INGESTION.md](INT_SEED_INGESTION.md) | `api/src/db/seed-integration.test.ts` | ✅ Implemented |
 
 ### Planned Scenarios (ML-Accelerated Roadmap)
 


### PR DESCRIPTION
## Summary

- Add `seed-integration.test.ts` — full integration test suite verifying the seed pipeline against a real PostgreSQL database (row counts, slug uniqueness, FK integrity, combiner relationships, junction tables, item correctness, idempotency)
- Add Gherkin scenario doc `INT_SEED_INGESTION.md` with 8 scenarios mapping 1:1 to test cases
- Backfill 5 missing changelog entries for PRs #14, #15, #32, #33, #42
Closes #24, Closes #31

## Test plan

- [x] Run `DATABASE_URL=... npm test` in `api/` to execute integration tests against a local PostgreSQL instance
- [x] Run `npm test` in `api/` without `DATABASE_URL` to verify tests skip gracefully
- [x] Verify changelog entries match their respective PR content

🤖 Generated with [Claude Code](https://claude.com/claude-code)