### PR TITLE
chore(infra): add project board linking rules and fix issue template

### DIFF
--- a/.claude/rules/issue-project-linking.md
+++ b/.claude/rules/issue-project-linking.md
@@ -1,0 +1,88 @@
+After creating a GitHub issue with `gh issue create`, ALWAYS link it to the project board and populate its fields.
+
+## Step 1: Add to project
+
+```
+gh project item-add 4 --owner butanoie --url <ISSUE_URL>
+```
+
+## Step 2: Get the item ID
+
+```
+gh project item-list 4 --owner butanoie --limit 10 | grep "<ISSUE_NUMBER>"
+```
+
+## Step 3: Set required fields
+
+Ask the user to confirm values for these fields, then set each one:
+
+**Status** (default: Todo)
+| Value | Option ID |
+|-------------|-----------|
+| Todo | f75ad846 |
+| In Progress | 47fc9ee4 |
+| Done | 98236657 |
+
+**Priority** (ask user)
+| Value | Option ID |
+|----------|-----------|
+| Critical | 1cd889a8 |
+| High | a7cb8ec5 |
+| Medium | 8c1927b3 |
+| Low | 1f5da5ad |
+
+**Phase** (ask user — match to roadmap phase)
+| Value | Option ID |
+|--------------------|-----------|
+| 1.4 Seed | b093ae15 |
+| 1.5 Catalog API | f3ce6de3 |
+| 1.5b Roles & Admin | 08508f52 |
+| 1.7 Catalog UI | 4de93c31 |
+| 1.9 Photos | 422665a3 |
+| 1.12 GDPR | afe95509 |
+| 4.0 ML | da0a83fc |
+| 2.0 iOS | f517f05c |
+| 1.6 Collection API | d48fbcc5 |
+| 1.8 Collection UI | 1486b874 |
+| 1.10 CSV Import | 8a2dc389 |
+| 1.11 Reporting | dea7d4a2 |
+| 3.0 Pricing | 5705530f |
+| 5.0 Polish | 6e677cfb |
+
+**Track** (ask user)
+| Value | Option ID |
+|----------|-----------|
+| ML Path | ed72bc4e |
+| Post-ML | 60752499 |
+| Backlog | 8d7cc674 |
+
+**Effort** (ask user)
+| Value | Option ID |
+|------------|-----------|
+| XS (< 2h) | 6831a86a |
+| S (2-4h) | 40f3ec98 |
+| M (4-8h) | a13661c4 |
+| L (1-2d) | 9eaff376 |
+| XL (3-5d) | a87135ab |
+
+## Step 4: Set each field
+
+```
+gh project item-edit --project-id PVT_kwHODzcfkc4BR7mS --id <ITEM_ID> \
+  --field-id <FIELD_ID> --single-select-option-id <OPTION_ID>
+```
+
+Field IDs:
+
+- Status: `PVTSSF_lAHODzcfkc4BR7mSzg_nO8o`
+- Priority: `PVTSSF_lAHODzcfkc4BR7mSzg_nPAQ`
+- Phase: `PVTSSF_lAHODzcfkc4BR7mSzg_nPAU`
+- Track: `PVTSSF_lAHODzcfkc4BR7mSzg_nPAw`
+- Effort: `PVTSSF_lAHODzcfkc4BR7mSzg_nPAY`
+
+## Step 5: Labels and Milestone
+
+Also set labels and milestone when creating the issue:
+
+- **Labels:** Use `--label` flags on `gh issue create`. Common labels: module (`api`, `web`, `ios`, `ml`), type (`type:feature`, `type:bug`, `type:chore`, `type:test`, `type:docs`), phase (`phase:X.Y`), priority (`priority:*`)
+- **Milestone:** Use `--milestone` flag. Milestones match phases (e.g., `1.5 Catalog API (Read)`, `1.5b User Roles & Admin`)

--- a/.claude/rules/pr-project-linking.md
+++ b/.claude/rules/pr-project-linking.md
@@ -1,0 +1,21 @@
+After creating a pull request with `gh pr create`, ALWAYS link it to the GitHub project board:
+
+1. Add the PR to the project:
+
+   ```
+   gh project item-add 4 --owner butanoie --url <PR_URL>
+   ```
+
+2. Set Status to "In Progress":
+   ```
+   gh project item-edit --project-id PVT_kwHODzcfkc4BR7mS --id <ITEM_ID> \
+     --field-id PVTSSF_lAHODzcfkc4BR7mSzg_nO8o --single-select-option-id 47fc9ee4
+   ```
+
+To get the item ID after adding, search the project items:
+
+```
+gh project item-list 4 --owner butanoie --limit 10 | grep "<PR_NUMBER>"
+```
+
+PRs only need Status set. Phase, Priority, Track, and Effort are tracked on the linked issue, not the PR.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -27,11 +27,11 @@ body:
         - '1.12 GDPR'
         - '4.0 ML'
         - '2.0 iOS'
-        - '1.6 Collection API (post-ML)'
-        - '1.8 Collection UI (post-ML)'
-        - '1.10 CSV Import (post-ML)'
-        - '1.11 Reporting (post-ML)'
-        - '3.0 Pricing (post-ML)'
+        - '1.6 Collection API'
+        - '1.8 Collection UI'
+        - '1.10 CSV Import'
+        - '1.11 Reporting'
+        - '3.0 Pricing'
         - '5.0 Polish'
   - type: textarea
     id: depends


### PR DESCRIPTION
## Summary

- Add Claude rules to automatically link PRs and issues to Track'em Toys Roadmap project board after creation
- Fix feature issue template Phase dropdown to match project board field names (removed `(post-ML)` suffixes)

## Details

**PR rule** (`.claude/rules/pr-project-linking.md`): After `gh pr create`, add PR to project and set Status to "In Progress"

**Issue rule** (`.claude/rules/issue-project-linking.md`): After `gh issue create`, add issue to project and prompt user for Phase, Priority, Track, Effort values. Includes all field/option IDs for `gh project item-edit`.

**Template fix**: Phase dropdown values in `.github/ISSUE_TEMPLATE/feature.yml` now match the project board exactly (e.g., `1.6 Collection API` instead of `1.6 Collection API (post-ML)`).

## Test plan

- [x] Rules are syntactically valid markdown and loaded by Claude Code automatically
- [x] Field IDs and option IDs verified against live project board
- [x] PR #50 successfully linked to project using these commands
- [x] All 29 existing issues retroactively added to project with Phase populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)