### PR TITLE
chore(infra): add env access rules, bug-fix gates, and code simplification step

### DIFF
--- a/.claude/rules/doc-gates-task-integration.md
+++ b/.claude/rules/doc-gates-task-integration.md
@@ -5,8 +5,9 @@ Required gate tasks:
 1. **"Architecture Review & Audit"** — after Architecture Design, before documentation. Blocks documentation. Review the design for consistency, security, data model correctness, dependency conflicts, edge cases, and scope creep.
 2. **"Post-Architecture Documentation Gate"** — after Architecture Review & Audit passes, before Implementation. Blocks implementation.
 3. **"Verification Gate: run /run-checks"** — after Implementation, before Quality Review.
-4. **"Post-Review Documentation Gate"** — after Quality Review, before Summary. Blocks summary.
-5. **"Run /changelog"** — after Summary. Create a changelog entry documenting the work.
-6. **"Run /claude-md-management:revise-claude-md"** — after Summary. Review session for CLAUDE.md improvements.
+4. **"Code Simplification: run code-simplifier agent"** — after Quality Review, before Post-Review Documentation Gate. Launch the `code-simplifier:code-simplifier` agent to simplify and refine recently written code.
+5. **"Post-Review Documentation Gate"** — after Code Simplification, before Summary. Blocks summary.
+6. **"Run /changelog"** — after Summary. Create a changelog entry documenting the work.
+7. **"Run /claude-md-management:revise-claude-md"** — after Summary. Review session for CLAUDE.md improvements.
 
 Without explicit tasks, the gates get skipped because they aren't visible in progress tracking. See `docs/guides/DOC_GATE_REFERENCE.md` for the full checklist.

--- a/.claude/rules/feature-dev-all-gates-for-bugs.md
+++ b/.claude/rules/feature-dev-all-gates-for-bugs.md
@@ -1,0 +1,9 @@
+When `/feature-dev:feature-dev` is invoked for a bug fix, the full 7-phase workflow and all gates still apply. Do not skip phases or gates because the task is a bug fix rather than a new feature.
+
+- **Clarifying questions** — Ask about the user's environment, reproduction steps, and observed vs expected behavior before investigating
+- **Architecture phase** — For bug fixes this means: present competing root cause hypotheses with evidence, get user confirmation on which to pursue before writing code
+- **Verification gate** — Run `/run-checks` after the fix
+- **Documentation gates** — Update docs if the fix reveals missing or incorrect documentation
+- **Changelog and CLAUDE.md revision** — Still required for non-trivial bug fixes
+
+Skipping phases leads to chasing wrong root causes and multiple incorrect fix iterations.

--- a/.claude/rules/feedback_no_env_access.md
+++ b/.claude/rules/feedback_no_env_access.md
@@ -1,0 +1,11 @@
+---
+name: Never access .env files
+description: Never read, grep, or modify .env files — only .env.example is allowed
+type: feedback
+---
+
+NEVER read, search, grep, or modify `.env` files — only `.env.example` is allowed.
+
+**Why:** The user has a `block-secrets.py` hook that blocks `Read` on `.env` files, but `Grep` and `Bash` tools can bypass it. The intent is to keep the agent away from secrets entirely. In a prior session, I circumvented the hook by using `Grep` to search `api/.env` for config values and `sed` to append lines — the user correctly flagged this as a violation.
+
+**How to apply:** When you need to know an `.env` value, ask the user. When changes to `.env` are needed, provide step-by-step instructions for the user to make the changes themselves. Only ever read or modify `.env.example` files directly.

--- a/.claude/rules/rules-over-memory.md
+++ b/.claude/rules/rules-over-memory.md
@@ -1,0 +1,6 @@
+When saving behavioral guidance (feedback, corrections, workflow rules), prefer `.claude/rules/` over memory if the guidance applies to all developers on the project — not just the current user.
+
+- **Rules** (`.claude/rules/*.md`): Portable, checked into git, enforced for every Claude session on this repo. Use for: workflow gates, tool restrictions, commit discipline, coding patterns.
+- **Memory** (`memory/*.md`): Per-user, not in git. Use for: individual preferences, user context (role, expertise), references to external systems the user mentioned.
+
+When in doubt, make it a rule.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,8 +9,13 @@ These rules are ABSOLUTE:
 - NEVER publish passwords, API keys, tokens to git/npm/docker
 - Before ANY commit: verify no secrets included
 
-### NEVER Commit .env Files
+### NEVER Read or Modify .env Files
 
+- NEVER read, grep, search, or modify `.env` files — they contain secrets
+- NEVER use `Grep`, `Bash`, `sed`, or any other tool to access `.env` file contents
+- Only `.env.example` files may be read or modified directly
+- When `.env` values are needed: **ask the user**
+- When `.env` changes are needed: **provide instructions for the user** to make the changes
 - NEVER commit `.env` to git
 - ALWAYS verify `.env` is in `.gitignore`
 

--- a/docs/guides/DOC_GATE_REFERENCE.md
+++ b/docs/guides/DOC_GATE_REFERENCE.md
@@ -48,9 +48,18 @@ Complete Step 1 (audit) fully before starting Step 2 (documentation). Review eac
 
 ---
 
-## Gate 2: Post-Review (After Quality Review Passes, Before Summary)
+## Code Simplification (After Quality Review, Before Post-Review Gate)
 
-**Trigger:** Review issues have been fixed and `/run-checks` passes.
+**Trigger:** Quality Review is complete and all review fixes are applied.
+**Blocks:** Post-Review Documentation Gate.
+
+Launch the `code-simplifier:code-simplifier` agent to simplify and refine recently written code for clarity, consistency, and maintainability. This runs as a subagent to avoid bloating the main conversation context.
+
+---
+
+## Gate 2: Post-Review (After Code Simplification, Before Summary)
+
+**Trigger:** Code simplification is complete and `/run-checks` still passes.
 **Blocks:** Summary cannot be written until this gate passes.
 
 ### Checklist


### PR DESCRIPTION
## Summary

- Add `.env` file access prohibition to CLAUDE.md and as a dedicated rule (`feedback_no_env_access.md`) — prevents bypassing the existing hook via Grep/Bash
- Add rule enforcing full 7-phase feature-dev workflow for bug fixes, not just new features
- Add `rules-over-memory.md` — prefer `.claude/rules/` for portable guidance, memory for per-user context
- Insert `code-simplifier:code-simplifier` agent step between Quality Review and Post-Review Documentation Gate in both `doc-gates-task-integration.md` and `DOC_GATE_REFERENCE.md`

## Test plan

- [ ] Verify `.env` access is blocked by both hook and rule (try `Read` on `.env`, confirm blocked)
- [ ] Verify `/feature-dev` on a bug fix still runs all gates
- [ ] Verify code-simplifier step appears in feature-dev task lists

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>