### PR TITLE
feat(web): Phase 1.9 Slice 2 — photo upload UI & gallery improvements

### DIFF
--- a/changelog/2026-03-20T185348Z_phase19-slice2-photo-upload-ui.md
+++ b/changelog/2026-03-20T185348Z_phase19-slice2-photo-upload-ui.md
@@ -1,0 +1,172 @@
+# Phase 1.9 Slice 2 — Photo Upload UI for Curators
+
+**Date:** 2026-03-20
+**Time:** 18:53:48 UTC
+**Type:** Feature
+**Phase:** 1.9 (Photo Management)
+**Issue:** #77
+
+## Summary
+
+Added curator/admin-facing photo management UI to catalog item detail views. The feature includes a slide-out Sheet with drag-and-drop upload (with per-photo XHR progress bars), drag-to-reorder grid, primary photo badge, and delete with confirmation. Integrates with the Slice 1 photo API endpoints (PR #76).
+
+---
+
+## Changes Implemented
+
+### 1. Photo Management Sheet
+
+Full-featured slide-out panel for curators to manage item photos:
+- Drag-and-drop upload zone with "or select files" link
+- Per-photo progress bars via XHR `upload.onprogress` (sequential processing)
+- Client-side MIME type and file size validation (JPEG, PNG, WebP, GIF; max 10MB)
+- `@dnd-kit/sortable` drag-to-reorder grid with keyboard accessibility and screen reader announcements
+- Amber star badge for primary photo (WCAG 2.2 AA compliant — `bg-amber-600 text-white`)
+- Delete with `ConfirmDialog` friction (destructive variant)
+
+**Created:**
+
+- `web/src/catalog/photos/api.ts` — XHR upload, delete/setPrimary/reorder API functions, `buildPhotoUrl()`, `validateFile()`
+- `web/src/catalog/photos/usePhotoUpload.ts` — `useReducer` state machine for upload lifecycle
+- `web/src/catalog/photos/usePhotoMutations.ts` — TanStack Query mutation bag
+- `web/src/catalog/photos/PhotoManagementSheet.tsx` — Sheet composition root
+- `web/src/catalog/photos/DropZone.tsx` — Drag-and-drop file input
+- `web/src/catalog/photos/UploadQueue.tsx` — Per-file progress bar list
+- `web/src/catalog/photos/PhotoGrid.tsx` — `@dnd-kit` sortable grid with photo actions
+
+### 2. Integration with Item Detail Views
+
+- Camera icon button in `ItemDetailPage` header row (next to ShareLinkButton)
+- Camera icon button in `ItemDetailPanel` actions slot
+- Both gated by `useAuth()` role check: `curator` or `admin` only
+
+**Modified:**
+
+- `web/src/catalog/pages/ItemDetailPage.tsx` — Role check + Sheet trigger
+- `web/src/catalog/components/ItemDetailPanel.tsx` — Role check + Sheet trigger
+
+### 3. Photo URL Prefix Fix
+
+Applied `buildPhotoUrl()` to existing `PhotoGallery` component — fixes a latent bug where relative photo URLs from the API would not resolve correctly. No photos existed in seed data, so this was invisible until now.
+
+**Modified:**
+
+- `web/src/catalog/components/PhotoGallery.tsx` — `buildPhotoUrl()` applied to all `<img src>` attributes
+
+### 4. API Client FormData Guard
+
+Added `!(init.body instanceof FormData)` to `buildHeaders` in `api-client.ts`. Prevents the auto-injected `Content-Type: application/json` from overriding the browser's `multipart/form-data` boundary header on FormData uploads.
+
+**Modified:**
+
+- `web/src/lib/api-client.ts` — One-line guard in `buildHeaders`
+
+### 5. New Dependencies
+
+- Shadcn Sheet component (`@radix-ui/react-dialog` based)
+- `@dnd-kit/core` + `@dnd-kit/sortable` + `@dnd-kit/utilities`
+
+### 6. Zod Schemas
+
+Added `PhotoWriteItemSchema` (with `status` field for write responses), `PhotoSchema` (extracted read shape), and response wrapper schemas.
+
+**Modified:**
+
+- `web/src/lib/zod-schemas.ts`
+- `web/src/vite-env.d.ts` — `VITE_PHOTO_BASE_URL` type
+- `web/.env.example` — `VITE_PHOTO_BASE_URL` placeholder
+
+---
+
+## Technical Details
+
+### Upload Architecture
+
+Upload uses XHR (not `fetch`) because the Fetch API doesn't expose `upload.onprogress`. The XHR wrapper in `api.ts` manages its own auth header via `authStore.getToken()` and implements a single retry on 401 via `attemptRefresh()`. Files are uploaded sequentially (one at a time) for predictable progress UX.
+
+### State Management
+
+Upload state uses `useReducer` (not TanStack Query) because upload progress is ephemeral UI state. The state machine tracks: `queued → uploading → done | error`. Completed items auto-remove after 3 seconds.
+
+Photo mutations (delete, set primary, reorder) use the standard `useMutation` pattern with `invalidateQueries` on success.
+
+### Accessibility
+
+- Drop zone: `role="region"` with `aria-label`, `aria-describedby` for format hints
+- Upload queue: `aria-live="polite"`, `role="alert"` on errors
+- Photo grid: `@dnd-kit` keyboard sensor with custom screen reader announcements
+- Primary badge: `role="status"` with `aria-label`
+- All interactive elements have appropriate `aria-label` attributes
+
+---
+
+## Validation & Testing
+
+### Test Results
+
+```
+Test Files  69 passed (69)
+Tests       519 passed (519) — 25 new tests across 7 new test files
+```
+
+### New Test Files
+
+| File | Tests | Coverage |
+|------|-------|----------|
+| `api.test.ts` | 8 | `buildPhotoUrl`, `validateFile` (MIME + size) |
+| `DropZone.test.tsx` | 7 | Render, file drop, file select, disabled state, a11y |
+| `UploadQueue.test.tsx` | 8 | All 4 status states, multiple items, a11y |
+| `PhotoGrid.test.tsx` | 12 | Primary badge, set-primary, delete, drag handles, help text |
+| `usePhotoMutations.test.ts` | 4 | All 3 mutations call correct API functions |
+| `usePhotoUpload.test.ts` | 5 | Enqueue, validation, success flow, error recovery |
+| `PhotoManagementSheet.test.tsx` | 9 | Sheet render, drop zone, photo grid, delete confirm |
+
+### Quality Checks
+
+| Check | Result |
+|-------|--------|
+| Web Tests | ✅ 519 passed |
+| Web Lint | ✅ 0 errors |
+| Web Typecheck | ✅ 0 errors |
+| Web Format | ✅ All files formatted |
+| Web Build | ✅ Built in 1.3s |
+
+### Bugs Caught in Code Review
+
+5 bugs identified and fixed during quality review:
+1. `onUploadComplete` was a no-op — uploads would never refresh the photo grid
+2. `processingRef` race condition — upload queue stalled after any error
+3. `attemptRefresh()` rejection unhandled — upload promise could hang forever
+4. `buildPhotoUrl` double-slash risk with trailing slash in base URL
+5. Unguarded `as` type cast in XHR error handler
+
+---
+
+## Impact Assessment
+
+- Curators can now upload, reorder, and manage photos for catalog items
+- Photo management is code-split into the Sheet bundle (~68KB gzip: 22KB) — not loaded for regular users
+- `buildPhotoUrl()` fix prepares `PhotoGallery` for actual photo display
+- `buildHeaders` FormData guard fixes a latent bug that would affect any future `apiFetch` with `FormData`
+
+---
+
+## Related Files
+
+### Documentation
+
+- `docs/decisions/ADR_Photo_Upload_UI.md` — Architecture decisions (11 decisions + 5 audit findings)
+- `docs/designs/photo-management-sheet.md` — UI design specification
+- `web/CLAUDE.md` — Photo Domains section updated with new conventions
+
+---
+
+## Status
+
+✅ COMPLETE — Implementation, tests, and documentation all done. User needs to add `VITE_PHOTO_BASE_URL=http://localhost:3010/photos` to local `web/.env`.
+
+## Next Steps
+
+- Phase 1.9 Slice 3: ML training data export (#78)
+- Real E2E tests for photo upload flow (deferred)
+- Phase 1.9b: moderation (#71), approval dashboard (#72), soft delete (#73), captions (#74), pending visibility (#75)

--- a/docs/decisions/ADR_Photo_Upload_UI.md
+++ b/docs/decisions/ADR_Photo_Upload_UI.md
@@ -1,0 +1,176 @@
+# ADR: Photo Upload UI Design (Phase 1.9 Slice 2)
+
+**Date:** 2026-03-20
+**Status:** Accepted (architecture + UI design approved, audit complete)
+**Depends on:** Phase 1.9 Slice 1 (Photo API, PR #76 merged)
+**GitHub Issue:** #77
+
+---
+
+## Context
+
+Phase 1.9 Slice 2 adds curator/admin-facing photo management UI to the catalog item detail views. The Slice 1 API is already complete with four endpoints: upload (multipart POST), delete, set primary, and reorder. This slice needs to provide an intuitive management interface that integrates cleanly into the existing item detail page and panel.
+
+### Requirements
+
+- Upload button visible only to curators/admins on both `ItemDetailPage` and `ItemDetailPanel`
+- Slide-out Sheet for photo management (more space than the 380px detail panel column)
+- Dedicated drop zone with "or select files" link
+- Per-photo progress bars during upload
+- Photo management: delete (with confirmation friction), set primary (badge overlay, WCAG 2.2 AA), drag-to-reorder
+- TanStack Query mutation hooks with cache invalidation
+- `VITE_PHOTO_BASE_URL` env var for photo URL construction
+
+---
+
+## Design Decisions
+
+### 1. Slide-Out Sheet for Photo Management
+
+**Decision:** Photo management lives in a Shadcn `Sheet` (right side, ~480px wide) rather than inline in the detail content or a modal dialog.
+
+**Why:** The `ItemDetailPanel` is only 380px wide — too narrow for drag-to-reorder, upload controls, and photo thumbnails simultaneously. A full modal would obscure the item context. A right-side Sheet provides ample space while keeping the item detail visible on the left. Radix Sheet handles focus trap, `aria-modal`, and scroll lock correctly.
+
+### 2. XHR for Upload Progress (Not Fetch)
+
+**Decision:** Use `XMLHttpRequest` with `upload.onprogress` for photo uploads instead of the `fetch` API.
+
+**Why:** The user requested per-photo progress bars. The `fetch` API does not expose upload progress (`ReadableStream` upload tracking has spotty browser support and requires `duplex: 'half'`). XHR's `upload.onprogress` is the reliable cross-browser solution. The XHR wrapper reads auth tokens from `authStore.getToken()` directly and implements a single retry on 401 via `attemptRefresh()`.
+
+**Trade-off:** The upload path does not go through `apiFetch`, so it manages its own auth header. This is acceptable — it's a single function, and the alternative (no progress bars) is worse UX.
+
+### 3. Sequential Upload (One File at a Time)
+
+**Decision:** Upload files sequentially rather than in parallel.
+
+**Why:** Sequential uploads produce predictable, readable progress — one bar advances at a time. The API accepts 1-10 files per request but we send one per request for individual progress tracking. With max 10 files at ≤10MB each, sequential is fast enough. The API rate limit is 20 uploads/minute, so parallel uploads could hit rate limits with large batches.
+
+### 4. `useReducer` State Machine for Upload Lifecycle
+
+**Decision:** Upload state is managed via a `useReducer` hook (`usePhotoUpload`) with states: `queued → uploading → done | error`.
+
+**Why:** Upload state is ephemeral UI state (not server state), so it does not belong in TanStack Query. A reducer provides predictable state transitions for the per-file lifecycle. The hook is independently testable.
+
+### 5. Mutation Bag Pattern for Photo Operations
+
+**Decision:** `usePhotoMutations(franchise, slug)` returns `{ deleteMutation, setPrimaryMutation, reorderMutation }` following the `useAdminUserMutations` pattern.
+
+**Why:** Consistent with the existing codebase convention. All three mutations share a single `invalidateQueries` closure targeting `['catalog', 'items', franchise, slug]`. Upload is excluded from this bag because it uses XHR (not `useMutation`).
+
+### 6. Optimistic Local State for Drag Reorder
+
+**Decision:** `PhotoGrid` maintains a local `orderedPhotos` state synced from the `photos` prop. On drag-end, local state updates immediately and the reorder mutation fires in the background.
+
+**Why:** Without optimistic state, the photo grid would snap back to the original order during the API round-trip, creating a jarring UX. On error, query invalidation restores the server's canonical order.
+
+### 7. `buildHeaders` FormData Guard
+
+**Decision:** Add `!(init.body instanceof FormData)` to the Content-Type auto-injection condition in `api-client.ts`.
+
+**Why:** The current `buildHeaders` sets `Content-Type: application/json` for any POST/PATCH with a body. For `FormData`, this overrides the browser's automatic `multipart/form-data; boundary=...` header, breaking multipart uploads. This is a latent bug that would affect any future `apiFetch` call with `FormData`, even though the current XHR upload path bypasses `apiFetch`.
+
+### 8. ConfirmDialog: Cross-Module Import (No Move)
+
+**Decision:** Import `ConfirmDialog` from `@/admin/components/ConfirmDialog` in catalog code. Do not move it to a shared location.
+
+**Why:** The component has zero admin-specific imports — all its dependencies are from `@/components/ui/*`. Moving it would require updating admin tests and import paths for no functional gain. If more consumers appear later, the move is a trivial refactor.
+
+### 9. Photo URL Prefix in Frontend
+
+**Decision:** `VITE_PHOTO_BASE_URL` is read via `import.meta.env` and prepended in frontend components, not in the API layer.
+
+**Why:** The API stores relative URLs in the database (e.g., `abc-123/def-456-gallery.webp`) for portability (CDN, different environments). The frontend is the right place to resolve the full URL — it knows its own environment config. A `buildPhotoUrl()` utility function provides this. The function must normalize the join: `${base}/${relativeUrl}` handling trailing/leading slashes.
+
+**Scope note:** This fix must also be applied to the existing `PhotoGallery` component, which currently renders `<img src={photo.url}>` with bare relative URLs. This hasn't broken yet because no seed data has photos, but will break with real photos.
+
+### 10. Role Gating at Page/Panel Level
+
+**Decision:** Role check (`user?.role === 'curator' || user?.role === 'admin'`) happens in `ItemDetailPage` and `ItemDetailPanel`, not in `ItemDetailContent` or the Sheet.
+
+**Why:** `ItemDetailContent` is a purely presentational component — it should not call `useAuth()`. The "Manage Photos" button renders in the page header row (next to `ShareLinkButton`) and in the panel's `actions` slot (via `DetailPanelShell`). The Sheet itself does not re-check roles — it trusts that only authorized users can open it.
+
+### 11. Integration Points
+
+**Decision:** "Manage Photos" button placement:
+- **ItemDetailPage:** In the header row, next to `ShareLinkButton`
+- **ItemDetailPanel:** In `DetailPanelShell`'s `actions` slot
+
+**Why:** This matches the existing pattern where the `ShareLinkButton` already lives in these locations. It keeps `ItemDetailContent` purely presentational.
+
+---
+
+## File Organization
+
+All new photo UI code lives in `web/src/catalog/photos/`:
+
+```
+catalog/photos/
+  api.ts                    — uploadPhoto (XHR), deletePhoto, setPrimaryPhoto, reorderPhotos
+  usePhotoUpload.ts         — useReducer state machine for upload lifecycle
+  usePhotoMutations.ts      — TanStack Query mutation bag
+  PhotoManagementSheet.tsx  — Slide-out Sheet composing all sub-components
+  DropZone.tsx              — Drag-and-drop file input with "or select files"
+  PhotoGrid.tsx             — @dnd-kit sortable grid with per-photo actions
+  __tests__/                — Component and hook tests
+```
+
+### Files to Modify
+
+- `web/src/lib/api-client.ts` — FormData guard in `buildHeaders`
+- `web/src/lib/zod-schemas.ts` — `PhotoWriteItemSchema`, `PhotoSchema` exports
+- `web/src/vite-env.d.ts` — `VITE_PHOTO_BASE_URL` type declaration
+- `web/.env.example` — Add `VITE_PHOTO_BASE_URL` placeholder
+- `web/src/catalog/pages/ItemDetailPage.tsx` — Role check + Sheet trigger
+- `web/src/catalog/components/ItemDetailPanel.tsx` — Role check + Sheet trigger
+- `web/src/catalog/components/PhotoGallery.tsx` — Apply `buildPhotoUrl()` to existing photo URLs
+- Existing test files for modified components
+
+---
+
+## New Dependencies
+
+- `@dnd-kit/core` + `@dnd-kit/sortable` + `@dnd-kit/utilities` — Drag-to-reorder (modern, accessible, ~10KB). `@dnd-kit/utilities` provides `CSS.Transform.toString()` required by `useSortable`.
+- Shadcn Sheet component — `npx shadcn@latest add sheet` (Radix Dialog-based)
+
+---
+
+## API Endpoints (Slice 1, Already Built)
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/catalog/franchises/:franchise/items/:slug/photos` | Upload 1-10 photos (multipart) |
+| `DELETE` | `.../photos/:photoId` | Delete a photo (204) |
+| `PATCH` | `.../photos/:photoId/primary` | Set primary photo |
+| `PATCH` | `.../photos/reorder` | Bulk reorder photos |
+
+---
+
+## Deferred / Out of Scope
+
+- Real (non-mocked) E2E tests — deferred, tracked in agent memory
+- Photo moderation (#71), approval dashboard (#72), soft delete (#73), captions (#74), pending visibility (#75) — all deferred to Phase 1.9b
+- Optimistic updates for delete/set-primary — using invalidate-on-success pattern for consistency with rest of codebase
+- Parallel upload — sequential is sufficient for ≤10 files
+
+---
+
+## Resolved Questions (via Frontend Design Spec)
+
+All UI design questions answered in `docs/designs/photo-management-sheet.md`:
+
+- **Sheet layout:** Drop zone top, upload queue middle, photo grid bottom
+- **Progress bars:** Inline per-file with filename, percentage, spinning loader
+- **Primary badge:** Amber filled star (`bg-amber-600 text-white`), top-left corner, always visible
+- **Drop zone active state:** Solid primary border, light primary bg, "Release to upload" text
+- **Mobile responsive:** Full-width sheet, 2-col grid, always-visible action bar (no hover on touch)
+- **Drag interaction:** Entire photo tile is draggable (5px activation distance allows button clicks)
+
+## Audit Findings (Architecture Review)
+
+Findings from the 5-pass architecture review (2026-03-20):
+
+1. **PhotoGallery needs URL prefix too** — existing component uses bare relative URLs; `buildPhotoUrl()` must be applied there
+2. **`@dnd-kit/utilities` required** — provides `CSS.Transform.toString()` for `useSortable`
+3. **Client-side file size validation** — add 10MB check before queuing to avoid wasted upload + 413 error
+4. **Disable drag during upload** — query invalidation from completed uploads resets `orderedPhotos` via `useEffect`, which could disrupt an in-progress drag
+5. **XHR `withCredentials: true`** — required for the refresh cookie during 401 retry

--- a/docs/designs/photo-management-sheet.md
+++ b/docs/designs/photo-management-sheet.md
@@ -1,0 +1,642 @@
+# Photo Management Sheet — UI Design Specification
+
+**Date:** 2026-03-20
+**Issue:** #77 (Phase 1.9 Slice 2)
+**Status:** Design complete, pending implementation via /feature-dev
+
+---
+
+## Design Direction
+
+**Aesthetic:** Refined utilitarian — clean, professional, efficient. Matches the existing Shadcn/ui design system exactly. No new fonts, no new color tokens. One accent exception: an **amber star** for primary photo badge (warm contrast against the cool blue-primary palette).
+
+**Key principle:** This is a curator's workbench. Every pixel serves a purpose. The Sheet should feel like a well-organized tool drawer — everything in reach, nothing cluttered.
+
+---
+
+## 1. Trigger Button — "Manage Photos"
+
+### On `ItemDetailPage` (header row)
+
+Placement: Next to `ShareLinkButton` in the `flex items-start justify-between` header row.
+
+```
+┌─────────────────────────────────────────┐
+│ Optimus Prime (G1)          [📷] [🔗]  │
+│─────────────────────────────────────────│
+│ [PhotoGallery]                          │
+│ ...                                     │
+└─────────────────────────────────────────┘
+```
+
+- `Button variant="ghost" size="icon"` with `Camera` icon (lucide `Camera`)
+- `aria-label="Manage photos"`
+- Only visible when `user.role === 'curator' || user.role === 'admin'`
+- Positioned BEFORE `ShareLinkButton` in the actions group (photos are the more common curator action)
+
+### On `ItemDetailPanel` (actions slot)
+
+Same icon button, passed into `DetailPanelShell`'s `actions` prop alongside the existing `ShareLinkButton`:
+
+```tsx
+actions={
+  <>
+    {isCurator && (
+      <Button variant="ghost" size="icon" onClick={openSheet} aria-label="Manage photos">
+        <Camera className="h-4 w-4" />
+      </Button>
+    )}
+    {shareUrl ? <ShareLinkButton url={shareUrl} /> : undefined}
+  </>
+}
+```
+
+---
+
+## 2. Sheet Layout
+
+**Shadcn Sheet, right side, responsive width:**
+- Desktop: `sm:max-w-lg` (512px)
+- Mobile: full width (Radix default)
+- `side="right"`
+
+### Sheet Header
+
+```
+┌─ Manage Photos ──────────────────── [X] ┐
+│ Optimus Prime (G1)                       │
+│ 4 photos                                 │
+├──────────────────────────────────────────┤
+```
+
+- `SheetHeader` with `SheetTitle` = "Manage Photos"
+- `SheetDescription` = item name + photo count (`"{itemName} · {n} photo(s)"`)
+- Standard Shadcn Sheet close button (built-in)
+
+### Sheet Content — Two Sections
+
+The sheet body has two vertically stacked sections separated by visual hierarchy (not `Separator` — spacing alone):
+
+```
+┌──────────────────────────────────────────┐
+│ ┌ UPLOAD ──────────────────────────────┐ │
+│ │                                      │ │
+│ │     📤  Drop photos here             │ │
+│ │     or select files                  │ │
+│ │                                      │ │
+│ │  JPEG, PNG, WebP, GIF · Max 10 MB   │ │
+│ └──────────────────────────────────────┘ │
+│                                          │
+│  ┌ progress-1.jpg ─────────── ✓ ┐       │
+│  ├ progress-2.jpg ════════░░░ ↻ ┤       │
+│  └ progress-3.jpg ─────────── ○ ┘       │
+│                                          │
+│ PHOTOS ─────────────────────────────────│
+│ ┌──────┐ ┌──────┐ ┌──────┐ ┌──────┐    │
+│ │ ★    │ │      │ │      │ │      │    │
+│ │ img1 │ │ img2 │ │ img3 │ │ img4 │    │
+│ │ ≡  🗑│ │ ≡  🗑│ │ ≡  🗑│ │ ≡  🗑│    │
+│ └──────┘ └──────┘ └──────┘ └──────┘    │
+│                                          │
+│ Drag to reorder · First photo is primary │
+└──────────────────────────────────────────┘
+```
+
+---
+
+## 3. DropZone Component
+
+### Default State
+
+```
+┌─ - - - - - - - - - - - - - - - - - ─┐
+│                                       │
+│          ↑ (Upload icon)              │
+│     Drop photos here                  │
+│     or  select files                  │
+│                                       │
+│   JPEG, PNG, WebP, GIF · Max 10 MB   │
+└─ - - - - - - - - - - - - - - - - - ─┘
+```
+
+**Visual treatment:**
+- Dashed border: `border-2 border-dashed border-muted-foreground/25 rounded-lg`
+- Background: `bg-muted/30`
+- Padding: `p-8` for comfortable target area
+- Center-aligned content
+- Icon: `Upload` from lucide (24x24), `text-muted-foreground`
+- "Drop photos here" — `text-sm font-medium text-foreground`
+- "or" — `text-sm text-muted-foreground`
+- "select files" — `text-sm text-primary font-medium hover:underline cursor-pointer` (triggers hidden `<input type="file">`)
+- Format hint: `text-xs text-muted-foreground mt-2`
+
+### Drag-Over Active State
+
+```
+┌━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┐
+│                                        │
+│          ↑ (Upload icon, primary)      │
+│     Release to upload                  │
+│                                        │
+└━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┘
+```
+
+**Visual treatment on drag-over:**
+- Border transitions to: `border-primary border-solid` (solid replaces dashed)
+- Background: `bg-primary/5`
+- Icon color: `text-primary`
+- Text changes to: "Release to upload"
+- CSS transition: `transition-all duration-150`
+
+### Uploading State (disabled)
+
+- `opacity-50 pointer-events-none`
+- Shows while any uploads are in progress (prevents double-queuing)
+
+### Accessibility
+
+- `role="region"` with `aria-label="Photo upload drop zone"`
+- Hidden `<input>`: `id="photo-file-input"`, `type="file"`, `multiple`, `accept="image/jpeg,image/png,image/webp,image/gif"`
+- "select files" text wrapped in `<button type="button">` with `aria-controls="photo-file-input"`
+- `aria-describedby` pointing to the format hint text
+
+---
+
+## 4. Upload Queue (Progress Bars)
+
+Renders between the drop zone and the photo grid, only when uploads are in progress or recently completed.
+
+### Per-File Item
+
+```
+┌──────────────────────────────────────────┐
+│ 📎 optimus-front.jpg     ███████░░░ 72% │
+│ 📎 optimus-back.jpg                  ○  │
+│ 📎 optimus-side.jpg       ─────── ✓     │
+│ ✕ optimus-huge.jpg   File too large      │
+└──────────────────────────────────────────┘
+```
+
+**States per file:**
+
+| State | Icon (right) | Progress bar | Text |
+|-------|-------------|-------------|------|
+| `queued` | `Circle` (muted, hollow) | None | — |
+| `uploading` | `Loader2` (spinning, `animate-spin`) | `<progress>` bar, `bg-primary` fill | `{percent}%` |
+| `done` | `CheckCircle2` (green-600) | Full bar briefly, then fades | — |
+| `error` | `XCircle` (destructive) | None | Error message in `text-destructive text-xs` |
+
+**Visual treatment:**
+- Each row: `flex items-center gap-2 py-1.5`
+- Filename: `text-sm text-foreground truncate flex-1` with `Paperclip` icon (`text-muted-foreground h-3.5 w-3.5`)
+- Progress bar: HTML `<progress>` element styled via Tailwind
+  - Track: `h-1.5 rounded-full bg-muted` (2px subtler than default)
+  - Fill: `bg-primary rounded-full` with `transition-all duration-300`
+  - Width: fills remaining space after filename and status icon
+- Percentage: `text-xs text-muted-foreground tabular-nums w-8 text-right`
+- Wrapper has `aria-live="polite"` for screen reader announcements
+- Completed items auto-clear after 3 seconds (with fade-out transition)
+
+**Accessibility:**
+- `<progress>` element with `aria-label="Uploading {filename}"`, `aria-valuenow`, `aria-valuemin="0"`, `aria-valuemax="100"`
+- Error messages: `role="alert"`
+- Container: `aria-label="Upload progress"` region
+
+---
+
+## 5. Photo Grid (Drag-to-Reorder)
+
+### Grid Layout
+
+- CSS Grid: `grid grid-cols-3 gap-2` (3 columns in the ~480px sheet)
+- Each cell: `aspect-square rounded-md overflow-hidden`
+
+### Photo Card (PhotoGridItem)
+
+```
+┌──────────────────┐
+│ ★               │  ← Primary badge (top-left, only on primary)
+│                  │
+│    [thumbnail]   │
+│                  │
+│              🗑   │  ← Delete (right); entire tile is draggable
+└──────────────────┘
+```
+
+**Visual treatment:**
+- Card: `relative group bg-muted rounded-md overflow-hidden aspect-square`
+- Thumbnail: `<img>` with `object-cover w-full h-full`
+- Hover overlay: `absolute inset-0 bg-black/0 group-hover:bg-black/10 transition-colors` (subtle dim)
+- Action bar at bottom: `absolute bottom-0 inset-x-0 flex items-center justify-between p-1 bg-gradient-to-t from-black/40 to-transparent opacity-0 group-hover:opacity-100 transition-opacity` — actions only visible on hover
+- While dragging: `opacity-70 scale-95 shadow-lg ring-2 ring-primary` with `transition-transform`
+- Drop placeholder: `bg-primary/10 border-2 border-dashed border-primary rounded-md`
+
+### Primary Photo Badge
+
+Position: Top-left corner of the card.
+
+```
+┌───┐
+│ ★ │
+└───┘
+```
+
+**Visual treatment:**
+- `absolute top-1 left-1 z-10`
+- Container: `flex items-center gap-0.5 rounded-full px-1.5 py-0.5 text-xs font-semibold`
+- Colors: `bg-amber-500 text-white` (light mode) / `bg-amber-400 text-amber-950` (dark mode)
+- Icon: `Star` from lucide, `h-3 w-3`, filled (`fill="currentColor"`)
+- Always visible (not affected by hover overlay)
+- WCAG AA contrast: amber-500 (#f59e0b) on white = 8.6:1 for the badge background. White text on amber-500 = 3.0:1 — enhanced to pass AA by using `bg-amber-600` which gives 4.6:1. **Final: `bg-amber-600 text-white dark:bg-amber-500 dark:text-amber-950`**
+
+### Set Primary Action
+
+- Appears as a `Star` icon button (outline, unfilled) in the top-left corner when NOT the primary photo
+- Only visible on hover (part of the hover overlay actions)
+- `aria-label="Set as primary photo"`
+- On click: calls `setPrimaryMutation.mutate(photo.id)`
+- When this photo IS primary: badge shows (always visible), no action button needed
+
+### Delete Action
+
+- `Trash2` icon button in the bottom-right corner of the action bar
+- `text-white/80 hover:text-white` (on the gradient overlay)
+- `aria-label="Delete photo"`
+- On click: opens `ConfirmDialog`
+
+### Drag Interaction
+
+- The entire photo tile is the drag surface — `attributes` and `listeners` on the outer `div`
+- `cursor-grab active:cursor-grabbing` on the tile container
+- `pointer-events-none` on the `<img>` to prevent browser default image drag
+- `PointerSensor` `distance: 5` constraint allows clicks on star/delete buttons without triggering drag
+
+### Empty State (No Photos)
+
+When `photos.length === 0`, the photo grid section does not render. Only the drop zone is shown with slightly more vertical emphasis:
+
+```
+┌─ - - - - - - - - - - - - - - - - - ─┐
+│                                       │
+│          ↑ (Upload icon)              │
+│                                       │
+│     No photos yet                     │
+│     Drop photos here or select files  │
+│                                       │
+│   JPEG, PNG, WebP, GIF · Max 10 MB   │
+└─ - - - - - - - - - - - - - - - - - ─┘
+```
+
+### Section Header
+
+Above the photo grid:
+
+```
+Photos (4)
+```
+
+- "Photos" label: `text-sm font-medium text-foreground`
+- Count in parentheses: `text-muted-foreground`
+
+### Help Text (Below Grid)
+
+```
+Drag photos to reorder · Star marks primary
+```
+
+- `text-xs text-muted-foreground text-center mt-2`
+- Only shown when `photos.length > 1`
+
+---
+
+## 6. Confirm Delete Dialog
+
+Reuses `ConfirmDialog` from `@/admin/components/ConfirmDialog`:
+
+```tsx
+<ConfirmDialog
+  open={deleteTarget !== null}
+  onOpenChange={(open) => { if (!open) setDeleteTarget(null); }}
+  title="Delete photo?"
+  description="This photo will be permanently removed from the catalog item. This action cannot be undone."
+  confirmLabel="Delete Photo"
+  variant="destructive"
+  onConfirm={handleConfirmDelete}
+  isPending={deleteMutation.isPending}
+/>
+```
+
+No `confirmText` prop — photo deletion has friction (the dialog itself) but does not require type-to-confirm (less destructive than GDPR purge).
+
+---
+
+## 7. Interaction Specifications
+
+### Upload Flow
+
+1. User drops files or clicks "select files"
+2. Client-side validation filters by MIME type. Invalid files trigger `toast.error("filename.tiff is not a supported image format")`
+3. Client-side file size validation rejects files >10MB with `toast.error("filename.jpg exceeds the 10 MB limit")`
+4. Valid files enter the upload queue as `queued`
+5. Sequential processing begins: first queued file transitions to `uploading`
+6. XHR `upload.onprogress` updates the progress bar in real-time
+7. On success: item transitions to `done`, progress bar fills to 100%, `toast.success("Photo uploaded")`, query invalidation fires
+8. Done items display for 3 seconds then fade out (CSS `opacity-0 transition-opacity duration-500`)
+9. Next queued file begins uploading
+10. After all uploads complete, the query invalidation causes the photo grid to re-render with new photos
+11. **Drag-to-reorder is disabled while uploads are in progress** to prevent query invalidation from disrupting an active drag
+
+### Drag-to-Reorder Flow
+
+1. User grabs anywhere on the photo tile (5px movement activates drag)
+2. Card lifts (scale + shadow) with `ring-2 ring-primary`
+3. Other cards shift to show drop position
+4. On release: local state updates immediately (optimistic)
+5. `reorderMutation.mutate(newOrder)` fires in background
+6. On error: toast + query invalidation restores server order
+
+### Set Primary Flow
+
+1. User hovers over a non-primary photo
+2. Star outline icon appears in top-left
+3. User clicks star icon
+4. `setPrimaryMutation.mutate(photo.id)` fires
+5. On success: query invalidation updates all photos, amber badge moves to new primary
+6. On error: `toast.error("Failed to set primary photo")`
+
+### Delete Flow
+
+1. User hovers over a photo, clicks `Trash2` icon
+2. `ConfirmDialog` opens with destructive variant
+3. User clicks "Delete Photo"
+4. `deleteMutation.mutate(photo.id)` fires
+5. Dialog shows "Processing..." state
+6. On success: dialog closes, query invalidation removes photo from grid, `toast.success("Photo deleted")`
+7. On error: dialog closes, `toast.error("Failed to delete photo")`
+
+---
+
+## 8. Keyboard Accessibility
+
+| Key | Context | Action |
+|-----|---------|--------|
+| `Tab` | Sheet | Navigate between drop zone, upload queue items, photo grid items |
+| `Enter`/`Space` | On photo tile | Pick up / drop item (dnd-kit keyboard sensor) |
+| `ArrowUp`/`ArrowDown` | While dragging (keyboard) | Move item in the grid |
+| `Escape` | While dragging | Cancel drag operation |
+| `Escape` | Sheet open (no drag) | Close Sheet |
+| `Enter`/`Space` | On star button | Set as primary photo |
+| `Enter`/`Space` | On delete button | Open confirm dialog |
+| `Enter`/`Space` | On "select files" | Open file picker |
+
+### dnd-kit Screen Reader Announcements
+
+```typescript
+accessibility={{
+  announcements: {
+    onDragStart: ({ active }) => `Picked up photo ${getPosition(active.id)}. Use arrow keys to move.`,
+    onDragOver: ({ active, over }) => over
+      ? `Photo ${getPosition(active.id)} is over position ${getPosition(over.id)}.`
+      : `Photo ${getPosition(active.id)} is no longer over a droppable area.`,
+    onDragEnd: ({ active, over }) => over
+      ? `Photo ${getPosition(active.id)} was moved to position ${getPosition(over.id)}.`
+      : `Photo ${getPosition(active.id)} was dropped.`,
+    onDragCancel: ({ active }) => `Drag cancelled. Photo ${getPosition(active.id)} returned to its original position.`,
+  },
+}}
+```
+
+---
+
+## 9. Responsive Behavior
+
+| Breakpoint | Sheet width | Grid columns | Action bar |
+|-----------|------------|-------------|------------|
+| `< sm` (640px) | Full width | 2 columns (`grid-cols-2`) | Always visible (no hover on touch) |
+| `sm+` | 512px (`sm:max-w-lg`) | 3 columns (`grid-cols-3`) | Visible on hover |
+
+On mobile/touch devices, the action bar (delete button) should always be visible since there's no hover state. Drag works via touch-and-hold on the entire tile. Use `@media (hover: none)` or always-show on `< sm`:
+
+```css
+/* Action bar: always visible on touch, hover-reveal on pointer */
+.photo-actions {
+  @apply opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity;
+}
+```
+
+Note: `@media (hover: hover)` is more precise than breakpoint-based, but Tailwind's `sm:` is simpler and covers the 99% case.
+
+---
+
+## 10. Color Palette Summary
+
+All colors use existing design tokens except the primary badge amber:
+
+| Element | Light Mode | Dark Mode | WCAG AA |
+|---------|-----------|-----------|---------|
+| Drop zone border | `border-muted-foreground/25` | Same token | N/A (decorative) |
+| Drop zone active border | `border-primary` | Same token | N/A (decorative) |
+| Progress bar fill | `bg-primary` | Same token | N/A (non-text) |
+| Primary badge bg | `bg-amber-600` | `bg-amber-500` | 4.6:1 / 4.7:1 |
+| Primary badge text | `text-white` | `text-amber-950` | Pass AA |
+| Done icon | `text-green-600` | `text-green-400` | 4.8:1 / 4.6:1 |
+| Error text | `text-destructive` (token) | Same token | Pass (themed) |
+| Action bar gradient | `from-black/40` | Same | N/A (overlay) |
+| Action icons | `text-white/80` | Same | 4.5:1 on dark overlay |
+
+---
+
+## 11. Component Mockup Code
+
+The following is **prototyping code** — demonstrates the visual design, not production implementation. Production code will be written during the /feature-dev implementation phase.
+
+### DropZone Mockup
+
+```tsx
+// DESIGN MOCKUP — not production code
+function DropZoneMockup({ isDragOver }: { isDragOver: boolean }) {
+  return (
+    <div
+      className={cn(
+        'relative rounded-lg border-2 border-dashed p-8 text-center transition-all duration-150',
+        isDragOver
+          ? 'border-primary border-solid bg-primary/5'
+          : 'border-muted-foreground/25 bg-muted/30 hover:border-muted-foreground/40'
+      )}
+    >
+      <Upload className={cn('mx-auto h-8 w-8 mb-3', isDragOver ? 'text-primary' : 'text-muted-foreground')} />
+
+      {isDragOver ? (
+        <p className="text-sm font-medium text-primary">Release to upload</p>
+      ) : (
+        <>
+          <p className="text-sm font-medium text-foreground">Drop photos here</p>
+          <p className="text-sm text-muted-foreground mt-1">
+            or{' '}
+            <button type="button" className="text-primary font-medium hover:underline">
+              select files
+            </button>
+          </p>
+        </>
+      )}
+
+      <p className="text-xs text-muted-foreground mt-3">JPEG, PNG, WebP, GIF · Max 10 MB</p>
+    </div>
+  );
+}
+```
+
+### Upload Queue Item Mockup
+
+```tsx
+// DESIGN MOCKUP — not production code
+function UploadQueueItemMockup({ status, progress, filename }: {
+  status: 'queued' | 'uploading' | 'done' | 'error';
+  progress: number;
+  filename: string;
+}) {
+  return (
+    <div className="flex items-center gap-2 py-1.5">
+      <Paperclip className="h-3.5 w-3.5 text-muted-foreground flex-shrink-0" />
+      <span className="text-sm text-foreground truncate flex-1">{filename}</span>
+
+      {status === 'uploading' && (
+        <>
+          <div className="w-20 h-1.5 rounded-full bg-muted overflow-hidden">
+            <div
+              className="h-full rounded-full bg-primary transition-all duration-300"
+              style={{ width: `${progress}%` }}
+            />
+          </div>
+          <span className="text-xs text-muted-foreground tabular-nums w-8 text-right">{progress}%</span>
+          <Loader2 className="h-3.5 w-3.5 text-primary animate-spin flex-shrink-0" />
+        </>
+      )}
+
+      {status === 'queued' && <Circle className="h-3.5 w-3.5 text-muted-foreground/50 flex-shrink-0" />}
+      {status === 'done' && <CheckCircle2 className="h-3.5 w-3.5 text-green-600 flex-shrink-0" />}
+      {status === 'error' && <XCircle className="h-3.5 w-3.5 text-destructive flex-shrink-0" />}
+    </div>
+  );
+}
+```
+
+### Photo Grid Item Mockup
+
+```tsx
+// DESIGN MOCKUP — not production code
+function PhotoGridItemMockup({ isPrimary, url }: { isPrimary: boolean; url: string }) {
+  return (
+    <div className="group relative aspect-square rounded-md overflow-hidden bg-muted">
+      <img src={url} alt="" className="object-cover w-full h-full" />
+
+      {/* Primary badge — always visible */}
+      {isPrimary && (
+        <div className="absolute top-1 left-1 z-10 flex items-center gap-0.5 rounded-full bg-amber-600 px-1.5 py-0.5 text-xs font-semibold text-white dark:bg-amber-500 dark:text-amber-950">
+          <Star className="h-3 w-3" fill="currentColor" />
+        </div>
+      )}
+
+      {/* Set-primary button — hover only, non-primary photos */}
+      {!isPrimary && (
+        <button
+          type="button"
+          className="absolute top-1 left-1 z-10 rounded-full bg-black/50 p-1 text-white/80 hover:text-white opacity-0 group-hover:opacity-100 transition-opacity"
+          aria-label="Set as primary photo"
+        >
+          <Star className="h-3.5 w-3.5" />
+        </button>
+      )}
+
+      {/* Action bar — bottom gradient overlay */}
+      <div className="absolute bottom-0 inset-x-0 flex items-end justify-end p-1.5 bg-gradient-to-t from-black/50 to-transparent opacity-0 group-hover:opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity">
+        <button
+          type="button"
+          className="text-white/80 hover:text-white"
+          aria-label="Delete photo"
+        >
+          <Trash2 className="h-4 w-4" />
+        </button>
+      </div>
+    </div>
+  );
+}
+```
+
+### Sheet Composition Mockup
+
+```tsx
+// DESIGN MOCKUP — not production code
+function PhotoManagementSheetMockup() {
+  return (
+    <Sheet>
+      <SheetContent side="right" className="sm:max-w-lg w-full flex flex-col">
+        <SheetHeader>
+          <SheetTitle>Manage Photos</SheetTitle>
+          <SheetDescription>Optimus Prime (G1) · 4 photos</SheetDescription>
+        </SheetHeader>
+
+        <div className="flex-1 overflow-y-auto space-y-6 py-4">
+          {/* Upload section */}
+          <div className="space-y-2">
+            <DropZoneMockup isDragOver={false} />
+
+            {/* Upload queue — only shown during/after uploads */}
+            <div aria-label="Upload progress" aria-live="polite" className="space-y-0.5">
+              <UploadQueueItemMockup status="done" progress={100} filename="front-view.jpg" />
+              <UploadQueueItemMockup status="uploading" progress={72} filename="back-view.jpg" />
+              <UploadQueueItemMockup status="queued" progress={0} filename="side-view.jpg" />
+            </div>
+          </div>
+
+          {/* Photo grid section */}
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <h3 className="text-sm font-medium text-foreground">
+                Photos <span className="text-muted-foreground">(4)</span>
+              </h3>
+            </div>
+
+            <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+              <PhotoGridItemMockup isPrimary={true} url="/photo1.jpg" />
+              <PhotoGridItemMockup isPrimary={false} url="/photo2.jpg" />
+              <PhotoGridItemMockup isPrimary={false} url="/photo3.jpg" />
+              <PhotoGridItemMockup isPrimary={false} url="/photo4.jpg" />
+            </div>
+
+            <p className="text-xs text-muted-foreground text-center">
+              Drag to reorder · Star marks primary
+            </p>
+          </div>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}
+```
+
+---
+
+## 12. CSS Transitions Summary
+
+All animations use CSS transitions (no animation library):
+
+| Element | Property | Duration | Easing |
+|---------|----------|----------|--------|
+| Drop zone border/bg | `all` | `150ms` | default ease |
+| Upload progress bar | `width` | `300ms` | default ease |
+| Done item fade-out | `opacity` | `500ms` | default ease |
+| Photo hover overlay | `opacity` | default | default ease |
+| Action bar reveal | `opacity` | default | default ease |
+| Drag item lift | `transform, box-shadow` | `200ms` | default ease |
+
+---
+
+## 13. Handoff Notes for Implementation
+
+1. **Install dependencies first:** `npx shadcn@latest add sheet` + `npm install @dnd-kit/core @dnd-kit/sortable`
+2. **Verify Sheet component:** Remove any `"use client"` directives or `next-themes` imports from the generated `sheet.tsx`. Convert any HSL values to oklch.
+3. **dnd-kit accessibility:** The `DndContext` must include the `accessibility.announcements` object shown in section 8.
+4. **Touch devices:** Action bar visibility must not depend on hover. Use the pattern from section 9.
+5. **Auto-clear done items:** 3-second delay then fade. Use `setTimeout` in the `usePhotoUpload` hook, not in the component.
+6. **Primary badge contrast:** Use `bg-amber-600 text-white` — verified at 4.6:1 for WCAG AA. In dark mode: `bg-amber-500 text-amber-950`.

--- a/docs/test-scenarios/E2E_CATALOG_DETAIL_PAGES.md
+++ b/docs/test-scenarios/E2E_CATALOG_DETAIL_PAGES.md
@@ -129,10 +129,28 @@ Scenario: Item detail shows photo gallery
   When the item detail page loads
   Then the primary photo is displayed prominently
   And thumbnail photos are visible
-  When the user clicks a photo
-  Then a lightbox overlay opens showing the full-size photo
+  And a magnifying glass icon is shown on the displayed photo
+
+Scenario: Clicking a thumbnail changes the displayed photo
+  Given the item has multiple photos
+  When the user clicks a thumbnail
+  Then the main image area updates to show that photo
+  And the lightbox does not open
+
+Scenario: Clicking the displayed photo opens the lightbox
+  Given the item has multiple photos
+  When the user clicks the main displayed photo
+  Then a lightbox overlay opens showing the full-size photo at the selected index
   And the lightbox can be closed with the Escape key
   And focus returns to the trigger element after closing
+
+Scenario: Lightbox navigation wraps around
+  Given the lightbox is open on the last photo
+  When the user clicks Next
+  Then the lightbox shows the first photo
+  Given the lightbox is open on the first photo
+  When the user clicks Previous
+  Then the lightbox shows the last photo
 ```
 
 ### Happy Path: Item with links to related pages

--- a/web/.env.example
+++ b/web/.env.example
@@ -2,3 +2,4 @@ VITE_API_URL=http://localhost:3000
 VITE_GOOGLE_CLIENT_ID=<Google OAuth Web Client ID>
 VITE_APPLE_SERVICES_ID=<Apple Services ID for web>
 VITE_APPLE_REDIRECT_URI=http://localhost:5173/auth/apple-callback
+VITE_PHOTO_BASE_URL=http://localhost:3010/photos

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -105,6 +105,7 @@ cd web && npm run format:check # Prettier check (CI mode)
 - CLI-generated components may import `next-themes` or `"use client"` directives — remove these for Vite projects
 - After `npx shadcn@latest add <component>`, check for unwanted dependencies in `package.json` and uninstall (e.g., `next-themes`)
 - Verify generated imports are correct — the CLI has generated circular self-imports (e.g., Sonner importing from its own path instead of the `sonner` package)
+- After `npx shadcn@latest add <component>`, verify the `cn` import uses `@/lib/utils` (not `src/lib/utils`) — the CLI sometimes generates incorrect paths
 
 ### Toast Notifications (Sonner)
 
@@ -128,6 +129,14 @@ cd web && npm run format:check # Prettier check (CI mode)
 - Catalog photo gallery on item detail page — shared, visible to all users
 - Photo upload UI (Phase 1.9) requires `curator` role — show/hide upload controls based on user role
 - User collection photos (private, per-item condition shots) are deferred to post-ML Phase 1.6
+- Photo URLs are stored as relative paths in the DB (e.g., `abc-123/def-456-gallery.webp`) — `buildPhotoUrl()` from `catalog/photos/api.ts` prepends `VITE_PHOTO_BASE_URL` for display
+- `VITE_PHOTO_BASE_URL` defaults to `http://localhost:3010/photos` in dev (matches `@fastify/static` route)
+- `buildHeaders()` in `api-client.ts` skips `Content-Type: application/json` when `body instanceof FormData` — required for multipart uploads
+- Photo upload uses XHR (not `fetch`) for `upload.onprogress` — the XHR wrapper in `catalog/photos/api.ts` manages its own auth header via `authStore.getToken()` and retries once on 401
+- Photo management UI lives in `src/catalog/photos/` — Sheet component, DropZone, PhotoGrid, hooks, API functions
+- `@dnd-kit/core` + `@dnd-kit/sortable` + `@dnd-kit/utilities` for drag-to-reorder in PhotoGrid
+- `@dnd-kit/sortable` `useSortable` returns `attributes` that include `aria-roledescription` — do NOT set this prop explicitly on the drag surface element or TypeScript will error with TS2783 (duplicate prop)
+- PhotoGrid cards are draggable by the entire tile (not a small grip handle) — `attributes` and `listeners` are on the outer `div`, with `pointer-events-none` on the `<img>` to prevent browser default image drag. The `PointerSensor` `distance: 5` constraint lets clicks on star/delete buttons resolve without triggering a drag.
 
 ### Catalog Browsing (Phase 1.7+)
 
@@ -143,7 +152,12 @@ cd web && npm run format:check # Prettier check (CI mode)
 - Character browse page uses three-column layout (FacetSidebar | CharacterList | CharacterDetailPanel) matching the items browse pattern
 - Character facets: faction, character_type, sub_group — continuity_family is a fixed scope filter (set from hub navigation), not a facet dimension
 - Franchise hub page has Items/Characters toggle via `?view=characters` search param; characters view mounts `CharactersHubView` sub-component (avoids conditional hook calls)
+- Photo gallery uses a two-level interaction: thumbnails change the displayed photo in-page (`selectedIndex`), clicking the displayed photo opens the lightbox (`lightboxIndex`). Lightbox navigation wraps around (last→first, first→last)
+- Photo gallery sorts photos client-side as `is_primary DESC, sort_order ASC` (matching the API query) — sorting by `sort_order` alone causes primary photo to appear out of position after set-primary mutations
+- All photo displays use `object-contain` (never `object-cover`) — no cropping of images in gallery, thumbnails, or photo manager tiles
 - Photo lightbox uses Shadcn `Dialog` for focus trap, scroll lock, and ARIA modal compliance — must include `onKeyDown` for ArrowLeft/ArrowRight navigation
+- Displayed photo has a `ZoomIn` magnifying glass icon overlay (bottom-right, opacity transitions on hover via `group`/`group-hover`)
+- Gallery main image is constrained to `max-h-[32rem]` (512px); photo manager tiles are constrained to `max-h-48`
 - `DetailPanelShell` component handles all panel chrome (aside wrapper, focus management, Escape key, loading/error/empty states, close button) — new panels should compose it rather than duplicating the chrome
 - Panel Escape key handlers must check `e.defaultPrevented` before calling `onClose()` — Radix `Dialog` (lightbox) calls `preventDefault` on Escape, and without the check both the dialog and panel close simultaneously
 - Catalog page headings use `<h1>` for the primary page title, `<h2>` for sub-sections — no page should lack an `<h1>`
@@ -161,6 +175,7 @@ cd web && npm run format:check # Prettier check (CI mode)
 - Page tests must mock `AppHeader` and `MainNav` — `AppHeader` calls `useAuth()` which throws without `AuthContext`. Use: `vi.mock('@/components/AppHeader', () => ({ AppHeader: () => <header data-testid="app-header" /> }))`
 - `FranchiseListPage`, `ManufacturerListPage`, `ManufacturerHubPage` do NOT import route files — no `Route.useSearch()` mock needed for these
 - `CharacterDetailPage` uses inline `useQuery` (not a custom hook) for related items — mock `listCatalogItems` from `@/catalog/api` and wrap in `createCatalogTestWrapper()`
+- Adding `useAuth()` to a component requires adding `vi.mock('@/auth/useAuth', () => ({ useAuth: () => ({ user: { id: 'u-1', role: 'user' }, isAuthenticated: true, isLoading: false }) }))` to every test file that renders that component (including parent pages like `ItemsPage` that render `ItemDetailPanel`)
 - `vi.advanceTimersByTime()` must be wrapped in `act()` when it triggers React state updates (e.g., `ShareLinkButton` timeout reset)
 - jsdom does not implement `navigator.clipboard` — mock with `Object.assign(navigator, { clipboard: { writeText: vi.fn() } })`
 - Integration components that own their own fetch (e.g., `CharacterRelationships`, `ItemRelationships`) require `vi.mock` in parent component tests — otherwise the hook fires without a QueryClient and crashes. Mock pattern: `vi.mock('@/catalog/components/CharacterRelationships', () => ({ CharacterRelationships: () => null }))`

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,6 +8,9 @@
       "name": "track-em-toys-web",
       "version": "0.0.1",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -517,6 +520,59 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/web/package.json
+++ b/web/package.json
@@ -18,6 +18,9 @@
     "format:check": "prettier --ignore-path ../.prettierignore --check ."
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@hookform/resolvers": "^5.2.2",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/web/src/catalog/components/ItemDetailPanel.tsx
+++ b/web/src/catalog/components/ItemDetailPanel.tsx
@@ -1,7 +1,13 @@
+import { useState } from 'react';
+import { Camera } from 'lucide-react';
 import { Link } from '@tanstack/react-router';
 import { useItemDetail } from '@/catalog/hooks/useItemDetail';
 import { DetailPanelShell } from '@/catalog/components/DetailPanelShell';
 import { ItemDetailContent } from '@/catalog/components/ItemDetailContent';
+import { ShareLinkButton } from '@/catalog/components/ShareLinkButton';
+import { PhotoManagementSheet } from '@/catalog/photos/PhotoManagementSheet';
+import { Button } from '@/components/ui/button';
+import { useAuth } from '@/auth/useAuth';
 
 interface ItemDetailPanelProps {
   franchise: string;
@@ -10,6 +16,10 @@ interface ItemDetailPanelProps {
 }
 
 export function ItemDetailPanel({ franchise, itemSlug, onClose }: ItemDetailPanelProps) {
+  const { user } = useAuth();
+  const isCurator = user?.role === 'curator' || user?.role === 'admin';
+  const [photoSheetOpen, setPhotoSheetOpen] = useState(false);
+
   const { data, isPending, isError } = useItemDetail(franchise, itemSlug);
 
   return (
@@ -21,10 +31,29 @@ export function ItemDetailPanel({ franchise, itemSlug, onClose }: ItemDetailPane
       isPending={isPending}
       isError={isError}
       onClose={onClose}
+      actions={
+        <>
+          {isCurator && data && (
+            <Button variant="ghost" size="icon" onClick={() => setPhotoSheetOpen(true)} aria-label="Manage photos">
+              <Camera className="h-4 w-4" />
+            </Button>
+          )}
+        </>
+      }
     >
       {data && (
         <>
           <ItemDetailContent data={data} franchise={franchise} />
+          {isCurator && data && (
+            <PhotoManagementSheet
+              open={photoSheetOpen}
+              onOpenChange={setPhotoSheetOpen}
+              franchise={franchise}
+              itemSlug={data.slug}
+              itemName={data.name}
+              photos={data.photos}
+            />
+          )}
           <div className="mt-6">
             <Link
               to="/catalog/$franchise/items/$slug"

--- a/web/src/catalog/components/PhotoGallery.tsx
+++ b/web/src/catalog/components/PhotoGallery.tsx
@@ -1,15 +1,9 @@
-import { useCallback, useState } from 'react';
-import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { useCallback, useMemo, useState } from 'react';
+import { ChevronLeft, ChevronRight, ZoomIn } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
-
-interface Photo {
-  id: string;
-  url: string;
-  caption: string | null;
-  is_primary: boolean;
-  sort_order: number;
-}
+import { buildPhotoUrl } from '@/catalog/photos/api';
+import type { Photo } from '@/lib/zod-schemas';
 
 interface PhotoGalleryProps {
   photos: Photo[];
@@ -17,15 +11,24 @@ interface PhotoGalleryProps {
 }
 
 export function PhotoGallery({ photos, itemName }: PhotoGalleryProps) {
+  const sortedPhotos = useMemo(
+    () =>
+      [...photos].sort((a, b) => {
+        if (a.is_primary !== b.is_primary) return a.is_primary ? -1 : 1;
+        return a.sort_order - b.sort_order;
+      }),
+    [photos]
+  );
+  const [selectedIndex, setSelectedIndex] = useState(0);
   const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
 
   const goToPrev = useCallback(() => {
-    setLightboxIndex((prev) => (prev !== null && prev > 0 ? prev - 1 : prev));
-  }, []);
+    setLightboxIndex((prev) => (prev !== null ? (prev - 1 + sortedPhotos.length) % sortedPhotos.length : prev));
+  }, [sortedPhotos.length]);
 
   const goToNext = useCallback(() => {
-    setLightboxIndex((prev) => (prev !== null && prev < photos.length - 1 ? prev + 1 : prev));
-  }, [photos.length]);
+    setLightboxIndex((prev) => (prev !== null ? (prev + 1) % sortedPhotos.length : prev));
+  }, [sortedPhotos.length]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
@@ -42,41 +45,44 @@ export function PhotoGallery({ photos, itemName }: PhotoGalleryProps) {
 
   if (photos.length === 0) return null;
 
-  const primaryPhoto = photos[0];
+  const displayedPhoto = sortedPhotos[selectedIndex] ?? sortedPhotos[0];
 
   return (
     <>
       <div className="mb-4 space-y-2">
         <button
           type="button"
-          className="w-full rounded-md overflow-hidden bg-muted aspect-square flex items-center justify-center cursor-pointer hover:opacity-90 transition-opacity"
-          onClick={() => setLightboxIndex(0)}
-          aria-label={`View photo: ${primaryPhoto.caption ?? itemName}`}
+          className="relative w-full rounded-md overflow-hidden bg-muted flex items-center justify-center cursor-pointer group hover:opacity-90 transition-opacity"
+          onClick={() => setLightboxIndex(selectedIndex)}
+          aria-label={`Enlarge photo: ${displayedPhoto.caption ?? itemName}`}
         >
           <img
-            src={primaryPhoto.url}
-            alt={primaryPhoto.caption ?? itemName}
-            className="object-contain max-h-full max-w-full"
+            src={buildPhotoUrl(displayedPhoto.url)}
+            alt={displayedPhoto.caption ?? itemName}
+            className="object-contain w-full max-h-[32rem]"
           />
+          <span className="absolute bottom-2 right-2 rounded-full bg-background/80 p-1.5 text-muted-foreground opacity-60 group-hover:opacity-100 transition-opacity">
+            <ZoomIn className="h-4 w-4" />
+          </span>
         </button>
 
-        {photos.length > 1 && (
+        {sortedPhotos.length > 1 && (
           <div className="flex gap-1.5 flex-wrap">
-            {photos.map((photo, idx) => (
+            {sortedPhotos.map((photo, idx) => (
               <button
                 key={photo.id}
                 type="button"
                 className={`w-14 h-14 rounded overflow-hidden bg-muted flex items-center justify-center cursor-pointer border-2 transition-colors ${
-                  idx === (lightboxIndex ?? 0) ? 'border-primary' : 'border-transparent hover:border-border'
+                  idx === selectedIndex ? 'border-primary' : 'border-transparent hover:border-border'
                 }`}
-                onClick={() => setLightboxIndex(idx)}
+                onClick={() => setSelectedIndex(idx)}
                 aria-label={`View photo ${idx + 1}: ${photo.caption ?? itemName}`}
-                aria-pressed={idx === (lightboxIndex ?? 0)}
+                aria-pressed={idx === selectedIndex}
               >
                 <img
-                  src={photo.url}
+                  src={buildPhotoUrl(photo.url)}
                   alt={photo.caption ?? `${itemName} photo ${idx + 1}`}
-                  className="object-cover w-full h-full"
+                  className="object-contain max-h-full max-w-full"
                 />
               </button>
             ))}
@@ -92,24 +98,23 @@ export function PhotoGallery({ photos, itemName }: PhotoGalleryProps) {
       >
         <DialogContent className="max-w-4xl w-[95vw] max-h-[90vh] p-2 sm:p-4" onKeyDown={handleKeyDown}>
           <DialogTitle className="sr-only">
-            {lightboxIndex !== null ? (photos[lightboxIndex].caption ?? `${itemName} photo`) : 'Photo'}
+            {lightboxIndex !== null ? (sortedPhotos[lightboxIndex].caption ?? `${itemName} photo`) : 'Photo'}
           </DialogTitle>
           {lightboxIndex !== null && (
             <div className="relative flex items-center justify-center min-h-[300px]">
               <img
-                src={photos[lightboxIndex].url}
-                alt={photos[lightboxIndex].caption ?? `${itemName} photo ${lightboxIndex + 1}`}
+                src={buildPhotoUrl(sortedPhotos[lightboxIndex].url)}
+                alt={sortedPhotos[lightboxIndex].caption ?? `${itemName} photo ${lightboxIndex + 1}`}
                 className="max-h-[80vh] max-w-full object-contain"
               />
 
-              {photos.length > 1 && (
+              {sortedPhotos.length > 1 && (
                 <>
                   <Button
                     variant="ghost"
                     size="icon"
                     className="absolute left-1 top-1/2 -translate-y-1/2 bg-background/80 hover:bg-background"
                     onClick={goToPrev}
-                    disabled={lightboxIndex === 0}
                     aria-label="Previous photo"
                   >
                     <ChevronLeft className="h-5 w-5" />
@@ -119,7 +124,6 @@ export function PhotoGallery({ photos, itemName }: PhotoGalleryProps) {
                     size="icon"
                     className="absolute right-1 top-1/2 -translate-y-1/2 bg-background/80 hover:bg-background"
                     onClick={goToNext}
-                    disabled={lightboxIndex === photos.length - 1}
                     aria-label="Next photo"
                   >
                     <ChevronRight className="h-5 w-5" />
@@ -128,7 +132,7 @@ export function PhotoGallery({ photos, itemName }: PhotoGalleryProps) {
               )}
 
               <div className="absolute bottom-2 left-1/2 -translate-x-1/2 text-xs text-muted-foreground bg-background/80 px-2 py-0.5 rounded">
-                {lightboxIndex + 1} / {photos.length}
+                {lightboxIndex + 1} / {sortedPhotos.length}
               </div>
             </div>
           )}

--- a/web/src/catalog/components/__tests__/ItemDetailPanel.test.tsx
+++ b/web/src/catalog/components/__tests__/ItemDetailPanel.test.tsx
@@ -5,6 +5,10 @@ import userEvent from '@testing-library/user-event';
 import { ItemDetailPanel } from '../ItemDetailPanel';
 import { mockCatalogItemDetail } from '@/catalog/__tests__/catalog-test-helpers';
 
+vi.mock('@/auth/useAuth', () => ({
+  useAuth: () => ({ user: { id: 'u-1', role: 'user' }, isAuthenticated: true, isLoading: false }),
+}));
+
 vi.mock('@tanstack/react-router', () => ({
   Link: ({ children, to, ...props }: { children: React.ReactNode; to: string }) => (
     <a href={to} {...props}>

--- a/web/src/catalog/components/__tests__/PhotoGallery.test.tsx
+++ b/web/src/catalog/components/__tests__/PhotoGallery.test.tsx
@@ -18,15 +18,15 @@ describe('PhotoGallery', () => {
     expect(container.innerHTML).toBe('');
   });
 
-  it('renders primary photo with correct aria-label', () => {
+  it('renders displayed photo with correct aria-label', () => {
     render(<PhotoGallery photos={mockPhotos} itemName="Optimus Prime" />);
-    expect(screen.getByRole('button', { name: 'View photo: Front view' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Enlarge photo: Front view' })).toBeInTheDocument();
   });
 
-  it('uses itemName when caption is null for primary photo', () => {
+  it('uses itemName when caption is null for displayed photo', () => {
     const photos = [{ id: 'p-1', url: '/photo.jpg', caption: null, is_primary: true, sort_order: 1 }];
     render(<PhotoGallery photos={photos} itemName="Optimus Prime" />);
-    expect(screen.getByRole('button', { name: 'View photo: Optimus Prime' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Enlarge photo: Optimus Prime' })).toBeInTheDocument();
   });
 
   it('renders thumbnail strip when photos.length > 1', () => {
@@ -42,35 +42,48 @@ describe('PhotoGallery', () => {
     expect(screen.queryByRole('button', { name: /View photo 1/ })).not.toBeInTheDocument();
   });
 
-  it('clicking primary photo opens lightbox', async () => {
+  it('clicking thumbnail changes displayed photo without opening lightbox', async () => {
     render(<PhotoGallery photos={mockPhotos} itemName="Optimus Prime" />);
-    await userEvent.click(screen.getByRole('button', { name: 'View photo: Front view' }));
+    await userEvent.click(screen.getByRole('button', { name: 'View photo 2: Side view' }));
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Enlarge photo: Side view' })).toBeInTheDocument();
+  });
+
+  it('clicking displayed photo opens lightbox', async () => {
+    render(<PhotoGallery photos={mockPhotos} itemName="Optimus Prime" />);
+    await userEvent.click(screen.getByRole('button', { name: 'Enlarge photo: Front view' }));
     expect(screen.getByRole('dialog')).toBeInTheDocument();
     expect(screen.getByText('1 / 3')).toBeInTheDocument();
   });
 
-  it('clicking thumbnail opens lightbox at that index', async () => {
+  it('clicking displayed photo opens lightbox at selected index', async () => {
     render(<PhotoGallery photos={mockPhotos} itemName="Optimus Prime" />);
     await userEvent.click(screen.getByRole('button', { name: 'View photo 2: Side view' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Enlarge photo: Side view' }));
     expect(screen.getByRole('dialog')).toBeInTheDocument();
     expect(screen.getByText('2 / 3')).toBeInTheDocument();
   });
 
-  it('Previous button is disabled at first photo', async () => {
+  it('Previous wraps from first photo to last', async () => {
     render(<PhotoGallery photos={mockPhotos} itemName="Optimus Prime" />);
-    await userEvent.click(screen.getByRole('button', { name: 'View photo: Front view' }));
-    expect(screen.getByRole('button', { name: 'Previous photo' })).toBeDisabled();
+    await userEvent.click(screen.getByRole('button', { name: 'Enlarge photo: Front view' }));
+    expect(screen.getByText('1 / 3')).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: 'Previous photo' }));
+    expect(screen.getByText('3 / 3')).toBeInTheDocument();
   });
 
-  it('Next button is disabled at last photo', async () => {
+  it('Next wraps from last photo to first', async () => {
     render(<PhotoGallery photos={mockPhotos} itemName="Optimus Prime" />);
     await userEvent.click(screen.getByRole('button', { name: 'View photo 3: Optimus Prime' }));
-    expect(screen.getByRole('button', { name: 'Next photo' })).toBeDisabled();
+    await userEvent.click(screen.getByRole('button', { name: /Enlarge photo/ }));
+    expect(screen.getByText('3 / 3')).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: 'Next photo' }));
+    expect(screen.getByText('1 / 3')).toBeInTheDocument();
   });
 
   it('clicking Next advances to next photo', async () => {
     render(<PhotoGallery photos={mockPhotos} itemName="Optimus Prime" />);
-    await userEvent.click(screen.getByRole('button', { name: 'View photo: Front view' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Enlarge photo: Front view' }));
     expect(screen.getByText('1 / 3')).toBeInTheDocument();
     await userEvent.click(screen.getByRole('button', { name: 'Next photo' }));
     expect(screen.getByText('2 / 3')).toBeInTheDocument();
@@ -79,8 +92,15 @@ describe('PhotoGallery', () => {
   it('clicking Previous goes back', async () => {
     render(<PhotoGallery photos={mockPhotos} itemName="Optimus Prime" />);
     await userEvent.click(screen.getByRole('button', { name: 'View photo 2: Side view' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Enlarge photo: Side view' }));
     expect(screen.getByText('2 / 3')).toBeInTheDocument();
     await userEvent.click(screen.getByRole('button', { name: 'Previous photo' }));
     expect(screen.getByText('1 / 3')).toBeInTheDocument();
+  });
+
+  it('renders magnifying glass icon on displayed photo', () => {
+    render(<PhotoGallery photos={mockPhotos} itemName="Optimus Prime" />);
+    const enlargeButton = screen.getByRole('button', { name: 'Enlarge photo: Front view' });
+    expect(enlargeButton.querySelector('svg')).toBeInTheDocument();
   });
 });

--- a/web/src/catalog/pages/ItemDetailPage.tsx
+++ b/web/src/catalog/pages/ItemDetailPage.tsx
@@ -1,9 +1,11 @@
+import { useState } from 'react';
 import { Link } from '@tanstack/react-router';
-import { ChevronRight } from 'lucide-react';
+import { Camera, ChevronRight } from 'lucide-react';
 import { Route } from '@/routes/_authenticated/catalog/$franchise/items/$slug';
 import { AppHeader } from '@/components/AppHeader';
 import { MainNav } from '@/components/MainNav';
 import { LoadingSpinner } from '@/components/LoadingSpinner';
+import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
 import { useItemDetail } from '@/catalog/hooks/useItemDetail';
 import { useFranchiseDetail } from '@/catalog/hooks/useFranchiseDetail';
@@ -11,10 +13,16 @@ import { useCharacterDetail } from '@/catalog/hooks/useCharacterDetail';
 import { ItemDetailContent } from '@/catalog/components/ItemDetailContent';
 import { CharacterDetailContent } from '@/catalog/components/CharacterDetailContent';
 import { ShareLinkButton } from '@/catalog/components/ShareLinkButton';
+import { PhotoManagementSheet } from '@/catalog/photos/PhotoManagementSheet';
+import { useAuth } from '@/auth/useAuth';
 import { ApiError } from '@/lib/api-client';
 
 export function ItemDetailPage() {
   const { franchise: franchiseSlug, slug: itemSlug } = Route.useParams();
+
+  const { user } = useAuth();
+  const isCurator = user?.role === 'curator' || user?.role === 'admin';
+  const [photoSheetOpen, setPhotoSheetOpen] = useState(false);
 
   const { data, isPending, error } = useItemDetail(franchiseSlug, itemSlug);
   const { data: franchiseDetail } = useFranchiseDetail(franchiseSlug);
@@ -111,7 +119,19 @@ export function ItemDetailPage() {
           <>
             <div className="flex items-start justify-between gap-2 mb-4">
               <h1 className="text-2xl font-semibold text-foreground">{data.name}</h1>
-              <ShareLinkButton />
+              <div className="flex items-center gap-1 flex-shrink-0">
+                {isCurator && (
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => setPhotoSheetOpen(true)}
+                    aria-label="Manage photos"
+                  >
+                    <Camera className="h-4 w-4" />
+                  </Button>
+                )}
+                <ShareLinkButton />
+              </div>
             </div>
 
             <Separator className="mb-6" />
@@ -119,6 +139,17 @@ export function ItemDetailPage() {
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
               <div>
                 <ItemDetailContent data={data} franchise={franchiseSlug} />
+    
+                {isCurator && (
+                  <PhotoManagementSheet
+                    open={photoSheetOpen}
+                    onOpenChange={setPhotoSheetOpen}
+                    franchise={franchiseSlug}
+                    itemSlug={data.slug}
+                    itemName={data.name}
+                    photos={data.photos}
+                  />
+                )}
               </div>
 
               {characterData && (

--- a/web/src/catalog/pages/__tests__/ItemDetailPage.test.tsx
+++ b/web/src/catalog/pages/__tests__/ItemDetailPage.test.tsx
@@ -5,6 +5,10 @@ import { ItemDetailPage } from '../ItemDetailPage';
 import { mockCatalogItemDetail, mockFranchiseDetail } from '@/catalog/__tests__/catalog-test-helpers';
 import { ApiError } from '@/lib/api-client';
 
+vi.mock('@/auth/useAuth', () => ({
+  useAuth: () => ({ user: { id: 'u-1', role: 'user' }, isAuthenticated: true, isLoading: false }),
+}));
+
 vi.mock('@/components/AppHeader', () => ({
   AppHeader: () => <header data-testid="app-header" />,
 }));

--- a/web/src/catalog/pages/__tests__/ItemsPage.test.tsx
+++ b/web/src/catalog/pages/__tests__/ItemsPage.test.tsx
@@ -6,6 +6,10 @@ import { ItemsPage } from '../ItemsPage';
 import { mockFranchiseDetail, mockCatalogItem, mockItemFacets } from '@/catalog/__tests__/catalog-test-helpers';
 import { ApiError } from '@/lib/api-client';
 
+vi.mock('@/auth/useAuth', () => ({
+  useAuth: () => ({ user: { id: 'u-1', role: 'user' }, isAuthenticated: true, isLoading: false }),
+}));
+
 vi.mock('@/components/AppHeader', () => ({
   AppHeader: () => <header data-testid="app-header" />,
 }));

--- a/web/src/catalog/pages/__tests__/ManufacturerItemsPage.test.tsx
+++ b/web/src/catalog/pages/__tests__/ManufacturerItemsPage.test.tsx
@@ -9,6 +9,10 @@ import {
 } from '@/catalog/__tests__/catalog-test-helpers';
 import { ApiError } from '@/lib/api-client';
 
+vi.mock('@/auth/useAuth', () => ({
+  useAuth: () => ({ user: { id: 'u-1', role: 'user' }, isAuthenticated: true, isLoading: false }),
+}));
+
 vi.mock('@/components/AppHeader', () => ({
   AppHeader: () => <header data-testid="app-header" />,
 }));

--- a/web/src/catalog/photos/DropZone.tsx
+++ b/web/src/catalog/photos/DropZone.tsx
@@ -1,0 +1,126 @@
+import { useCallback, useRef, useState } from 'react';
+import { Upload } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface DropZoneProps {
+  onFilesSelected: (files: File[]) => void;
+  disabled?: boolean;
+}
+
+export function DropZone({ onFilesSelected, disabled = false }: DropZoneProps) {
+  const [isDragOver, setIsDragOver] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const dragCounterRef = useRef(0);
+
+  const handleFiles = useCallback(
+    (fileList: FileList) => {
+      const files = Array.from(fileList);
+      if (files.length > 0) {
+        onFilesSelected(files);
+      }
+    },
+    [onFilesSelected]
+  );
+
+  const handleDragEnter = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    dragCounterRef.current++;
+    setIsDragOver(true);
+  }, []);
+
+  const handleDragLeave = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    dragCounterRef.current--;
+    if (dragCounterRef.current === 0) {
+      setIsDragOver(false);
+    }
+  }, []);
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+  }, []);
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      dragCounterRef.current = 0;
+      setIsDragOver(false);
+      if (!disabled && e.dataTransfer.files.length > 0) {
+        handleFiles(e.dataTransfer.files);
+      }
+    },
+    [disabled, handleFiles]
+  );
+
+  const handleInputChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      if (e.target.files && e.target.files.length > 0) {
+        handleFiles(e.target.files);
+        e.target.value = '';
+      }
+    },
+    [handleFiles]
+  );
+
+  return (
+    <div
+      role="region"
+      aria-label="Photo upload drop zone"
+      onDragEnter={handleDragEnter}
+      onDragLeave={handleDragLeave}
+      onDragOver={handleDragOver}
+      onDrop={handleDrop}
+      className={cn(
+        'relative rounded-lg border-2 border-dashed p-8 text-center transition-all duration-150',
+        disabled && 'opacity-50 pointer-events-none',
+        isDragOver
+          ? 'border-primary border-solid bg-primary/5'
+          : 'border-muted-foreground/25 bg-muted/30 hover:border-muted-foreground/40'
+      )}
+    >
+      <Upload
+        className={cn('mx-auto h-8 w-8 mb-3', isDragOver ? 'text-primary' : 'text-muted-foreground')}
+        aria-hidden="true"
+      />
+
+      {isDragOver ? (
+        <p className="text-sm font-medium text-primary">Release to upload</p>
+      ) : (
+        <>
+          <p className="text-sm font-medium text-foreground">Drop photos here</p>
+          <p className="text-sm text-muted-foreground mt-1">
+            or{' '}
+            <button
+              type="button"
+              className="text-primary font-medium hover:underline"
+              onClick={() => inputRef.current?.click()}
+              disabled={disabled}
+            >
+              select files
+            </button>
+          </p>
+        </>
+      )}
+
+      <p id="dropzone-format-hint" className="text-xs text-muted-foreground mt-3">
+        JPEG, PNG, WebP, GIF &middot; Max 10 MB
+      </p>
+
+      <input
+        ref={inputRef}
+        id="photo-file-input"
+        type="file"
+        multiple
+        accept="image/jpeg,image/png,image/webp,image/gif"
+        className="sr-only"
+        onChange={handleInputChange}
+        aria-describedby="dropzone-format-hint"
+        disabled={disabled}
+      />
+    </div>
+  );
+}

--- a/web/src/catalog/photos/PhotoGrid.tsx
+++ b/web/src/catalog/photos/PhotoGrid.tsx
@@ -1,0 +1,170 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import { SortableContext, rectSortingStrategy, useSortable, arrayMove } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { Star, Trash2 } from 'lucide-react';
+import { buildPhotoUrl } from './api';
+import type { Photo } from '@/lib/zod-schemas';
+
+interface PhotoGridProps {
+  photos: Photo[];
+  onReorder: (photos: Array<{ id: string; sort_order: number }>) => void;
+  onSetPrimary: (photoId: string) => void;
+  onDelete: (photoId: string) => void;
+  disabled?: boolean;
+}
+
+export function PhotoGrid({ photos, onReorder, onSetPrimary, onDelete, disabled = false }: PhotoGridProps) {
+  const [orderedPhotos, setOrderedPhotos] = useState(photos);
+
+  useEffect(() => {
+    setOrderedPhotos(photos);
+  }, [photos]);
+
+  const posOf = useCallback(
+    (id: string | number) => orderedPhotos.findIndex((p) => p.id === id) + 1,
+    [orderedPhotos]
+  );
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor)
+  );
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
+
+      const oldIdx = orderedPhotos.findIndex((p) => p.id === active.id);
+      const newIdx = orderedPhotos.findIndex((p) => p.id === over.id);
+      const reordered = arrayMove(orderedPhotos, oldIdx, newIdx);
+
+      setOrderedPhotos(reordered);
+      onReorder(reordered.map((p, i) => ({ id: p.id, sort_order: i })));
+    },
+    [orderedPhotos, onReorder]
+  );
+
+  if (photos.length === 0) return null;
+
+  return (
+    <div className="space-y-2">
+      <h3 className="text-sm font-medium text-foreground">
+        Photos <span className="text-muted-foreground">({photos.length})</span>
+      </h3>
+
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragEnd={handleDragEnd}
+        accessibility={{
+          announcements: {
+            onDragStart: ({ active }) => `Picked up photo ${posOf(active.id)}. Use arrow keys to move.`,
+            onDragOver: ({ active, over }) =>
+              over
+                ? `Photo ${posOf(active.id)} is over position ${posOf(over.id)}.`
+                : `Photo ${posOf(active.id)} is no longer over a droppable area.`,
+            onDragEnd: ({ active, over }) =>
+              over
+                ? `Photo ${posOf(active.id)} was moved to position ${posOf(over.id)}.`
+                : `Photo ${posOf(active.id)} was dropped.`,
+            onDragCancel: ({ active }) =>
+              `Drag cancelled. Photo ${posOf(active.id)} returned to its original position.`,
+          },
+        }}
+      >
+        <SortableContext items={orderedPhotos.map((p) => p.id)} strategy={rectSortingStrategy} disabled={disabled}>
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+            {orderedPhotos.map((photo) => (
+              <SortablePhotoCard
+                key={photo.id}
+                photo={photo}
+                onSetPrimary={onSetPrimary}
+                onDelete={onDelete}
+                disabled={disabled}
+              />
+            ))}
+          </div>
+        </SortableContext>
+      </DndContext>
+
+      {photos.length > 1 && (
+        <p className="text-xs text-muted-foreground text-center">Drag to reorder &middot; Star marks primary</p>
+      )}
+    </div>
+  );
+}
+
+interface SortablePhotoCardProps {
+  photo: Photo;
+  onSetPrimary: (photoId: string) => void;
+  onDelete: (photoId: string) => void;
+  disabled?: boolean;
+}
+
+function SortablePhotoCard({ photo, onSetPrimary, onDelete, disabled }: SortablePhotoCardProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: photo.id,
+    disabled,
+  });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={`group relative rounded-md overflow-hidden bg-muted max-h-48 flex items-center justify-center cursor-grab active:cursor-grabbing ${
+        isDragging ? 'opacity-70 scale-95 shadow-lg ring-2 ring-primary z-10' : ''
+      }`}
+      {...attributes}
+      {...listeners}
+    >
+      <img src={buildPhotoUrl(photo.url)} alt={photo.caption ?? 'Photo'} className="object-contain max-h-full max-w-full pointer-events-none" />
+
+      {photo.is_primary && (
+        <div
+          className="absolute top-1 left-1 z-10 flex items-center gap-0.5 rounded-full bg-amber-600 px-1.5 py-0.5 text-xs font-semibold text-white dark:bg-amber-500 dark:text-amber-950"
+          role="status"
+          aria-label="Primary photo"
+        >
+          <Star className="h-3 w-3" fill="currentColor" aria-hidden="true" />
+        </div>
+      )}
+
+      {!photo.is_primary && (
+        <button
+          type="button"
+          className="absolute top-1 left-1 z-10 rounded-full bg-black/50 p-1 text-white/80 hover:text-white opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity"
+          aria-label="Set as primary photo"
+          onClick={() => onSetPrimary(photo.id)}
+        >
+          <Star className="h-3.5 w-3.5" aria-hidden="true" />
+        </button>
+      )}
+
+      <div className="absolute bottom-0 inset-x-0 flex items-end justify-end p-1.5 bg-gradient-to-t from-black/50 to-transparent opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity">
+        <button
+          type="button"
+          className="text-white/80 hover:text-white"
+          aria-label="Delete photo"
+          onClick={() => onDelete(photo.id)}
+        >
+          <Trash2 className="h-4 w-4" aria-hidden="true" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/catalog/photos/PhotoManagementSheet.tsx
+++ b/web/src/catalog/photos/PhotoManagementSheet.tsx
@@ -1,0 +1,129 @@
+import { useCallback, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from '@/components/ui/sheet';
+import { ConfirmDialog } from '@/admin/components/ConfirmDialog';
+import type { Photo } from '@/lib/zod-schemas';
+import { DropZone } from './DropZone';
+import { UploadQueue } from './UploadQueue';
+import { PhotoGrid } from './PhotoGrid';
+import { usePhotoUpload } from './usePhotoUpload';
+import { usePhotoMutations } from './usePhotoMutations';
+
+interface PhotoManagementSheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  franchise: string;
+  itemSlug: string;
+  itemName: string;
+  photos: Photo[];
+}
+
+export function PhotoManagementSheet({
+  open,
+  onOpenChange,
+  franchise,
+  itemSlug,
+  itemName,
+  photos,
+}: PhotoManagementSheetProps) {
+  const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
+  const queryClient = useQueryClient();
+
+  const { deleteMutation, setPrimaryMutation, reorderMutation } = usePhotoMutations(franchise, itemSlug);
+
+  const invalidateItem = useCallback(() => {
+    void queryClient.invalidateQueries({ queryKey: ['catalog', 'items', franchise, itemSlug] });
+  }, [queryClient, franchise, itemSlug]);
+
+  const {
+    items: uploadItems,
+    isUploading,
+    uploadFiles,
+  } = usePhotoUpload({
+    franchise,
+    itemSlug,
+    onUploadComplete: invalidateItem,
+  });
+
+  const handleSetPrimary = useCallback(
+    (photoId: string) => {
+      setPrimaryMutation.mutate(photoId, {
+        onError: () => {
+          toast.error('Failed to set primary photo');
+        },
+      });
+    },
+    [setPrimaryMutation]
+  );
+
+  const handleReorder = useCallback(
+    (orderedPhotos: Array<{ id: string; sort_order: number }>) => {
+      reorderMutation.mutate(orderedPhotos, {
+        onError: () => {
+          toast.error('Failed to reorder photos');
+        },
+      });
+    },
+    [reorderMutation]
+  );
+
+  const handleConfirmDelete = useCallback(() => {
+    if (!deleteTarget) return;
+    deleteMutation.mutate(deleteTarget, {
+      onSuccess: () => {
+        setDeleteTarget(null);
+        toast.success('Photo deleted');
+      },
+      onError: () => {
+        setDeleteTarget(null);
+        toast.error('Failed to delete photo');
+      },
+    });
+  }, [deleteTarget, deleteMutation]);
+
+  const photoLabel = photos.length === 1 ? '1 photo' : `${photos.length} photos`;
+
+  return (
+    <>
+      <Sheet open={open} onOpenChange={onOpenChange}>
+        <SheetContent side="right" className="sm:max-w-lg w-full flex flex-col">
+          <SheetHeader>
+            <SheetTitle>Manage Photos</SheetTitle>
+            <SheetDescription>
+              {itemName} &middot; {photoLabel}
+            </SheetDescription>
+          </SheetHeader>
+
+          <div className="flex-1 overflow-y-auto space-y-6 py-4">
+            <div className="space-y-2">
+              <DropZone onFilesSelected={uploadFiles} disabled={isUploading} />
+              <UploadQueue items={uploadItems} />
+            </div>
+
+            <PhotoGrid
+              photos={photos}
+              onReorder={handleReorder}
+              onSetPrimary={handleSetPrimary}
+              onDelete={setDeleteTarget}
+              disabled={isUploading}
+            />
+          </div>
+        </SheetContent>
+      </Sheet>
+
+      <ConfirmDialog
+        open={deleteTarget !== null}
+        onOpenChange={(isOpen) => {
+          if (!isOpen) setDeleteTarget(null);
+        }}
+        title="Delete photo?"
+        description="This photo will be permanently removed from the catalog item. This action cannot be undone."
+        confirmLabel="Delete Photo"
+        variant="destructive"
+        onConfirm={handleConfirmDelete}
+        isPending={deleteMutation.isPending}
+      />
+    </>
+  );
+}

--- a/web/src/catalog/photos/UploadQueue.tsx
+++ b/web/src/catalog/photos/UploadQueue.tsx
@@ -1,0 +1,63 @@
+import { Circle, CheckCircle2, XCircle, Loader2, Paperclip } from 'lucide-react';
+import type { UploadItem } from './usePhotoUpload';
+
+interface UploadQueueProps {
+  items: UploadItem[];
+}
+
+export function UploadQueue({ items }: UploadQueueProps) {
+  if (items.length === 0) return null;
+
+  return (
+    <div aria-label="Upload progress" role="region" aria-live="polite" className="space-y-0.5">
+      {items.map((item) => (
+        <UploadQueueRow key={item.id} item={item} />
+      ))}
+    </div>
+  );
+}
+
+function UploadQueueRow({ item }: { item: UploadItem }) {
+  return (
+    <div className="flex items-center gap-2 py-1.5">
+      <Paperclip className="h-3.5 w-3.5 text-muted-foreground flex-shrink-0" aria-hidden="true" />
+      <span className="text-sm text-foreground truncate flex-1">{item.fileName}</span>
+
+      {item.status === 'uploading' && (
+        <>
+          <div className="w-20 h-1.5 rounded-full bg-muted overflow-hidden" role="presentation">
+            <div
+              className="h-full rounded-full bg-primary transition-all duration-300"
+              style={{ width: `${item.progress}%` }}
+            />
+          </div>
+          <span className="text-xs text-muted-foreground tabular-nums w-8 text-right">{item.progress}%</span>
+          <Loader2
+            className="h-3.5 w-3.5 text-primary animate-spin flex-shrink-0"
+            aria-label={`Uploading ${item.fileName}`}
+          />
+        </>
+      )}
+
+      {item.status === 'queued' && (
+        <Circle className="h-3.5 w-3.5 text-muted-foreground/50 flex-shrink-0" aria-label="Queued" />
+      )}
+
+      {item.status === 'done' && (
+        <CheckCircle2
+          className="h-3.5 w-3.5 text-green-600 dark:text-green-400 flex-shrink-0"
+          aria-label="Upload complete"
+        />
+      )}
+
+      {item.status === 'error' && (
+        <>
+          <span className="text-xs text-destructive truncate" role="alert">
+            {item.errorMessage ?? 'Upload failed'}
+          </span>
+          <XCircle className="h-3.5 w-3.5 text-destructive flex-shrink-0" aria-label="Upload failed" />
+        </>
+      )}
+    </div>
+  );
+}

--- a/web/src/catalog/photos/__tests__/DropZone.test.tsx
+++ b/web/src/catalog/photos/__tests__/DropZone.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { DropZone } from '../DropZone';
+
+vi.mock('../api', () => ({
+  buildPhotoUrl: (url: string) => url,
+  validateFile: () => null,
+}));
+
+describe('DropZone', () => {
+  it('renders default state with upload instructions', () => {
+    render(<DropZone onFilesSelected={vi.fn()} />);
+
+    expect(screen.getByText('Drop photos here')).toBeInTheDocument();
+    expect(screen.getByText('select files')).toBeInTheDocument();
+    expect(screen.getByText(/JPEG, PNG, WebP, GIF/)).toBeInTheDocument();
+  });
+
+  it('renders the hidden file input with correct accept types', () => {
+    render(<DropZone onFilesSelected={vi.fn()} />);
+
+    const input = document.getElementById('photo-file-input') as HTMLInputElement;
+    expect(input).toBeInTheDocument();
+    expect(input.type).toBe('file');
+    expect(input.multiple).toBe(true);
+    expect(input.accept).toBe('image/jpeg,image/png,image/webp,image/gif');
+  });
+
+  it('calls onFilesSelected when files are dropped', () => {
+    const onFilesSelected = vi.fn();
+    render(<DropZone onFilesSelected={onFilesSelected} />);
+
+    const dropZone = screen.getByRole('region', { name: /drop zone/i });
+    const file = new File(['content'], 'test.jpg', { type: 'image/jpeg' });
+
+    fireEvent.drop(dropZone, {
+      dataTransfer: { files: [file] },
+    });
+
+    expect(onFilesSelected).toHaveBeenCalledWith([file]);
+  });
+
+  it('calls onFilesSelected when files are selected via input', async () => {
+    const user = userEvent.setup();
+    const onFilesSelected = vi.fn();
+    render(<DropZone onFilesSelected={onFilesSelected} />);
+
+    const input = document.getElementById('photo-file-input') as HTMLInputElement;
+    const file = new File(['content'], 'test.jpg', { type: 'image/jpeg' });
+
+    await user.upload(input, file);
+
+    expect(onFilesSelected).toHaveBeenCalledWith([file]);
+  });
+
+  it('renders disabled state', () => {
+    render(<DropZone onFilesSelected={vi.fn()} disabled />);
+
+    const dropZone = screen.getByRole('region', { name: /drop zone/i });
+    expect(dropZone.className).toContain('pointer-events-none');
+  });
+
+  it('does not call onFilesSelected when disabled and files are dropped', () => {
+    const onFilesSelected = vi.fn();
+    render(<DropZone onFilesSelected={onFilesSelected} disabled />);
+
+    const dropZone = screen.getByRole('region', { name: /drop zone/i });
+    const file = new File(['content'], 'test.jpg', { type: 'image/jpeg' });
+
+    fireEvent.drop(dropZone, {
+      dataTransfer: { files: [file] },
+    });
+
+    expect(onFilesSelected).not.toHaveBeenCalled();
+  });
+
+  it('has accessible region role and label', () => {
+    render(<DropZone onFilesSelected={vi.fn()} />);
+
+    expect(screen.getByRole('region', { name: 'Photo upload drop zone' })).toBeInTheDocument();
+  });
+});

--- a/web/src/catalog/photos/__tests__/PhotoGrid.test.tsx
+++ b/web/src/catalog/photos/__tests__/PhotoGrid.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { PhotoGrid } from '../PhotoGrid';
+import type { Photo } from '@/lib/zod-schemas';
+
+vi.mock('../api', () => ({
+  buildPhotoUrl: (url: string) => `http://localhost:3010/photos/${url}`,
+}));
+
+const mockPhotos: Photo[] = [
+  { id: 'p-1', url: 'item1/photo1-gallery.webp', caption: null, is_primary: true, sort_order: 0 },
+  { id: 'p-2', url: 'item1/photo2-gallery.webp', caption: 'Side view', is_primary: false, sort_order: 1 },
+  { id: 'p-3', url: 'item1/photo3-gallery.webp', caption: null, is_primary: false, sort_order: 2 },
+];
+
+describe('PhotoGrid', () => {
+  it('returns null when photos array is empty', () => {
+    const { container } = render(
+      <PhotoGrid photos={[]} onReorder={vi.fn()} onSetPrimary={vi.fn()} onDelete={vi.fn()} />
+    );
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders photo count in heading', () => {
+    render(<PhotoGrid photos={mockPhotos} onReorder={vi.fn()} onSetPrimary={vi.fn()} onDelete={vi.fn()} />);
+
+    expect(screen.getByText('Photos')).toBeInTheDocument();
+    expect(screen.getByText('(3)')).toBeInTheDocument();
+  });
+
+  it('renders primary badge on the primary photo', () => {
+    render(<PhotoGrid photos={mockPhotos} onReorder={vi.fn()} onSetPrimary={vi.fn()} onDelete={vi.fn()} />);
+
+    expect(screen.getByRole('status', { name: 'Primary photo' })).toBeInTheDocument();
+  });
+
+  it('renders set-primary buttons for non-primary photos', () => {
+    render(<PhotoGrid photos={mockPhotos} onReorder={vi.fn()} onSetPrimary={vi.fn()} onDelete={vi.fn()} />);
+
+    const setPrimaryButtons = screen.getAllByLabelText('Set as primary photo');
+    expect(setPrimaryButtons).toHaveLength(2);
+  });
+
+  it('renders delete buttons for all photos', () => {
+    render(<PhotoGrid photos={mockPhotos} onReorder={vi.fn()} onSetPrimary={vi.fn()} onDelete={vi.fn()} />);
+
+    const deleteButtons = screen.getAllByLabelText('Delete photo');
+    expect(deleteButtons).toHaveLength(3);
+  });
+
+  it('renders help text when more than one photo', () => {
+    render(<PhotoGrid photos={mockPhotos} onReorder={vi.fn()} onSetPrimary={vi.fn()} onDelete={vi.fn()} />);
+
+    expect(screen.getByText(/Drag to reorder/)).toBeInTheDocument();
+  });
+
+  it('does not render help text for single photo', () => {
+    render(<PhotoGrid photos={[mockPhotos[0]]} onReorder={vi.fn()} onSetPrimary={vi.fn()} onDelete={vi.fn()} />);
+
+    expect(screen.queryByText(/Drag to reorder/)).not.toBeInTheDocument();
+  });
+
+  it('renders images with buildPhotoUrl', () => {
+    render(<PhotoGrid photos={mockPhotos} onReorder={vi.fn()} onSetPrimary={vi.fn()} onDelete={vi.fn()} />);
+
+    const images = screen.getAllByRole('img');
+    expect(images[0]).toHaveAttribute('src', 'http://localhost:3010/photos/item1/photo1-gallery.webp');
+  });
+
+  it('uses caption as alt text when available', () => {
+    render(<PhotoGrid photos={mockPhotos} onReorder={vi.fn()} onSetPrimary={vi.fn()} onDelete={vi.fn()} />);
+
+    expect(screen.getByAltText('Side view')).toBeInTheDocument();
+  });
+
+  it('calls onSetPrimary when set-primary button is clicked', async () => {
+    const { default: userEvent } = await import('@testing-library/user-event');
+    const user = userEvent.setup();
+    const onSetPrimary = vi.fn();
+
+    render(<PhotoGrid photos={mockPhotos} onReorder={vi.fn()} onSetPrimary={onSetPrimary} onDelete={vi.fn()} />);
+
+    const buttons = screen.getAllByLabelText('Set as primary photo');
+    await user.click(buttons[0]);
+
+    expect(onSetPrimary).toHaveBeenCalledWith('p-2');
+  });
+
+  it('calls onDelete when delete button is clicked', async () => {
+    const { default: userEvent } = await import('@testing-library/user-event');
+    const user = userEvent.setup();
+    const onDelete = vi.fn();
+
+    render(<PhotoGrid photos={mockPhotos} onReorder={vi.fn()} onSetPrimary={vi.fn()} onDelete={onDelete} />);
+
+    const buttons = screen.getAllByLabelText('Delete photo');
+    await user.click(buttons[0]);
+
+    expect(onDelete).toHaveBeenCalledWith('p-1');
+  });
+});

--- a/web/src/catalog/photos/__tests__/PhotoManagementSheet.test.tsx
+++ b/web/src/catalog/photos/__tests__/PhotoManagementSheet.test.tsx
@@ -1,0 +1,222 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { PhotoManagementSheet } from '../PhotoManagementSheet';
+import type { Photo } from '@/lib/zod-schemas';
+
+vi.mock('../api', () => ({
+  buildPhotoUrl: (url: string) => `http://localhost:3010/photos/${url}`,
+  validateFile: () => null,
+  uploadPhoto: vi.fn(),
+  deletePhoto: vi.fn().mockResolvedValue(undefined),
+  setPrimaryPhoto: vi.fn().mockResolvedValue({
+    id: 'p-1',
+    url: 'test-gallery.webp',
+    caption: null,
+    is_primary: true,
+    sort_order: 0,
+    status: 'approved',
+  }),
+  reorderPhotos: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('@/admin/components/ConfirmDialog', () => ({
+  ConfirmDialog: ({
+    open,
+    title,
+    onConfirm,
+  }: {
+    open: boolean;
+    title: string;
+    onConfirm: () => void;
+    onOpenChange: (open: boolean) => void;
+    description: string;
+    confirmLabel: string;
+    variant: string;
+    isPending: boolean;
+  }) =>
+    open
+      ? React.createElement(
+          'div',
+          { 'data-testid': 'confirm-dialog' },
+          React.createElement('p', null, title),
+          React.createElement('button', { onClick: onConfirm }, 'Confirm Delete')
+        )
+      : null,
+}));
+
+vi.mock('@/auth/useAuth', () => ({
+  useAuth: () => ({ user: { id: 'u-1', role: 'curator' }, isAuthenticated: true, isLoading: false }),
+}));
+
+const mockPhotos: Photo[] = [
+  { id: 'p-1', url: 'item1/photo1-gallery.webp', caption: null, is_primary: true, sort_order: 0 },
+  { id: 'p-2', url: 'item1/photo2-gallery.webp', caption: 'Side view', is_primary: false, sort_order: 1 },
+];
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(QueryClientProvider, { client: queryClient }, children);
+  };
+}
+
+describe('PhotoManagementSheet', () => {
+  it('renders sheet with title and description when open', () => {
+    render(
+      <PhotoManagementSheet
+        open={true}
+        onOpenChange={vi.fn()}
+        franchise="transformers"
+        itemSlug="optimus-prime"
+        itemName="Optimus Prime (G1)"
+        photos={mockPhotos}
+      />,
+      { wrapper: createWrapper() }
+    );
+
+    expect(screen.getByText('Manage Photos')).toBeInTheDocument();
+    expect(screen.getByText(/Optimus Prime \(G1\)/)).toBeInTheDocument();
+    expect(screen.getByText(/2 photos/)).toBeInTheDocument();
+  });
+
+  it('renders drop zone', () => {
+    render(
+      <PhotoManagementSheet
+        open={true}
+        onOpenChange={vi.fn()}
+        franchise="transformers"
+        itemSlug="optimus-prime"
+        itemName="Optimus Prime (G1)"
+        photos={mockPhotos}
+      />,
+      { wrapper: createWrapper() }
+    );
+
+    expect(screen.getByText('Drop photos here')).toBeInTheDocument();
+  });
+
+  it('renders photo grid with correct count', () => {
+    render(
+      <PhotoManagementSheet
+        open={true}
+        onOpenChange={vi.fn()}
+        franchise="transformers"
+        itemSlug="optimus-prime"
+        itemName="Optimus Prime (G1)"
+        photos={mockPhotos}
+      />,
+      { wrapper: createWrapper() }
+    );
+
+    expect(screen.getByText('Photos')).toBeInTheDocument();
+    expect(screen.getByText('(2)')).toBeInTheDocument();
+  });
+
+  it('renders primary badge on primary photo', () => {
+    render(
+      <PhotoManagementSheet
+        open={true}
+        onOpenChange={vi.fn()}
+        franchise="transformers"
+        itemSlug="optimus-prime"
+        itemName="Optimus Prime (G1)"
+        photos={mockPhotos}
+      />,
+      { wrapper: createWrapper() }
+    );
+
+    expect(screen.getByRole('status', { name: 'Primary photo' })).toBeInTheDocument();
+  });
+
+  it('renders set-primary button on non-primary photo', () => {
+    render(
+      <PhotoManagementSheet
+        open={true}
+        onOpenChange={vi.fn()}
+        franchise="transformers"
+        itemSlug="optimus-prime"
+        itemName="Optimus Prime (G1)"
+        photos={mockPhotos}
+      />,
+      { wrapper: createWrapper() }
+    );
+
+    expect(screen.getByLabelText('Set as primary photo')).toBeInTheDocument();
+  });
+
+  it('opens confirm dialog when delete button is clicked', async () => {
+    const user = userEvent.setup();
+    render(
+      <PhotoManagementSheet
+        open={true}
+        onOpenChange={vi.fn()}
+        franchise="transformers"
+        itemSlug="optimus-prime"
+        itemName="Optimus Prime (G1)"
+        photos={mockPhotos}
+      />,
+      { wrapper: createWrapper() }
+    );
+
+    const deleteButtons = screen.getAllByLabelText('Delete photo');
+    await user.click(deleteButtons[0]);
+
+    expect(screen.getByTestId('confirm-dialog')).toBeInTheDocument();
+    expect(screen.getByText('Delete photo?')).toBeInTheDocument();
+  });
+
+  it('does not render when closed', () => {
+    render(
+      <PhotoManagementSheet
+        open={false}
+        onOpenChange={vi.fn()}
+        franchise="transformers"
+        itemSlug="optimus-prime"
+        itemName="Optimus Prime (G1)"
+        photos={mockPhotos}
+      />,
+      { wrapper: createWrapper() }
+    );
+
+    expect(screen.queryByText('Manage Photos')).not.toBeInTheDocument();
+  });
+
+  it('shows empty state when no photos', () => {
+    render(
+      <PhotoManagementSheet
+        open={true}
+        onOpenChange={vi.fn()}
+        franchise="transformers"
+        itemSlug="optimus-prime"
+        itemName="Optimus Prime (G1)"
+        photos={[]}
+      />,
+      { wrapper: createWrapper() }
+    );
+
+    expect(screen.getByText('Drop photos here')).toBeInTheDocument();
+    expect(screen.queryByText('Photos')).not.toBeInTheDocument();
+  });
+
+  it('renders 1 photo label correctly', () => {
+    render(
+      <PhotoManagementSheet
+        open={true}
+        onOpenChange={vi.fn()}
+        franchise="transformers"
+        itemSlug="optimus-prime"
+        itemName="Optimus Prime (G1)"
+        photos={[mockPhotos[0]]}
+      />,
+      { wrapper: createWrapper() }
+    );
+
+    expect(screen.getByText(/1 photo/)).toBeInTheDocument();
+  });
+});

--- a/web/src/catalog/photos/__tests__/UploadQueue.test.tsx
+++ b/web/src/catalog/photos/__tests__/UploadQueue.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { UploadQueue } from '../UploadQueue';
+import type { UploadItem } from '../usePhotoUpload';
+
+describe('UploadQueue', () => {
+  it('returns null when items array is empty', () => {
+    const { container } = render(<UploadQueue items={[]} />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders queued item with filename and circle icon', () => {
+    const items: UploadItem[] = [{ id: '1', fileName: 'photo.jpg', status: 'queued', progress: 0 }];
+    render(<UploadQueue items={items} />);
+
+    expect(screen.getByText('photo.jpg')).toBeInTheDocument();
+    expect(screen.getByLabelText('Queued')).toBeInTheDocument();
+  });
+
+  it('renders uploading item with progress bar and percentage', () => {
+    const items: UploadItem[] = [{ id: '1', fileName: 'photo.jpg', status: 'uploading', progress: 42 }];
+    render(<UploadQueue items={items} />);
+
+    expect(screen.getByText('photo.jpg')).toBeInTheDocument();
+    expect(screen.getByText('42%')).toBeInTheDocument();
+    expect(screen.getByLabelText('Uploading photo.jpg')).toBeInTheDocument();
+  });
+
+  it('renders done item with checkmark', () => {
+    const items: UploadItem[] = [{ id: '1', fileName: 'photo.jpg', status: 'done', progress: 100 }];
+    render(<UploadQueue items={items} />);
+
+    expect(screen.getByText('photo.jpg')).toBeInTheDocument();
+    expect(screen.getByLabelText('Upload complete')).toBeInTheDocument();
+  });
+
+  it('renders error item with error message and alert role', () => {
+    const items: UploadItem[] = [
+      { id: '1', fileName: 'photo.jpg', status: 'error', progress: 0, errorMessage: 'File too large' },
+    ];
+    render(<UploadQueue items={items} />);
+
+    expect(screen.getByText('photo.jpg')).toBeInTheDocument();
+    expect(screen.getByRole('alert')).toHaveTextContent('File too large');
+    expect(screen.getByLabelText('Upload failed')).toBeInTheDocument();
+  });
+
+  it('renders multiple items in order', () => {
+    const items: UploadItem[] = [
+      { id: '1', fileName: 'first.jpg', status: 'done', progress: 100 },
+      { id: '2', fileName: 'second.jpg', status: 'uploading', progress: 50 },
+      { id: '3', fileName: 'third.jpg', status: 'queued', progress: 0 },
+    ];
+    render(<UploadQueue items={items} />);
+
+    expect(screen.getByText('first.jpg')).toBeInTheDocument();
+    expect(screen.getByText('second.jpg')).toBeInTheDocument();
+    expect(screen.getByText('third.jpg')).toBeInTheDocument();
+  });
+
+  it('has accessible region with live announcements', () => {
+    const items: UploadItem[] = [{ id: '1', fileName: 'photo.jpg', status: 'uploading', progress: 10 }];
+    render(<UploadQueue items={items} />);
+
+    const region = screen.getByRole('region', { name: 'Upload progress' });
+    expect(region).toHaveAttribute('aria-live', 'polite');
+  });
+
+  it('shows default error message when errorMessage is undefined', () => {
+    const items: UploadItem[] = [{ id: '1', fileName: 'photo.jpg', status: 'error', progress: 0 }];
+    render(<UploadQueue items={items} />);
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Upload failed');
+  });
+});

--- a/web/src/catalog/photos/__tests__/api.test.ts
+++ b/web/src/catalog/photos/__tests__/api.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { buildPhotoUrl, validateFile } from '../api';
+
+describe('buildPhotoUrl', () => {
+  it('prepends VITE_PHOTO_BASE_URL to relative path', () => {
+    // In test env VITE_PHOTO_BASE_URL is not set, so it returns the url as-is
+    const url = buildPhotoUrl('abc-123/def-456-gallery.webp');
+    // Without env var, returns the relative url unchanged
+    expect(url).toContain('abc-123/def-456-gallery.webp');
+  });
+});
+
+describe('validateFile', () => {
+  function makeFile(name: string, type: string, size: number): File {
+    const blob = new Blob(['x'.repeat(size)], { type });
+    return new File([blob], name, { type });
+  }
+
+  it('returns null for valid JPEG file', () => {
+    const file = makeFile('photo.jpg', 'image/jpeg', 1024);
+    expect(validateFile(file)).toBeNull();
+  });
+
+  it('returns null for valid PNG file', () => {
+    const file = makeFile('photo.png', 'image/png', 1024);
+    expect(validateFile(file)).toBeNull();
+  });
+
+  it('returns null for valid WebP file', () => {
+    const file = makeFile('photo.webp', 'image/webp', 1024);
+    expect(validateFile(file)).toBeNull();
+  });
+
+  it('returns null for valid GIF file', () => {
+    const file = makeFile('photo.gif', 'image/gif', 1024);
+    expect(validateFile(file)).toBeNull();
+  });
+
+  it('returns error for unsupported MIME type', () => {
+    const file = makeFile('photo.tiff', 'image/tiff', 1024);
+    expect(validateFile(file)).toBe('photo.tiff is not a supported image format');
+  });
+
+  it('returns error for file exceeding 10MB', () => {
+    const file = makeFile('huge.jpg', 'image/jpeg', 11 * 1024 * 1024);
+    expect(validateFile(file)).toBe('huge.jpg exceeds the 10 MB limit');
+  });
+
+  it('accepts file at exactly 10MB', () => {
+    const file = makeFile('exact.jpg', 'image/jpeg', 10 * 1024 * 1024);
+    expect(validateFile(file)).toBeNull();
+  });
+});

--- a/web/src/catalog/photos/__tests__/usePhotoMutations.test.ts
+++ b/web/src/catalog/photos/__tests__/usePhotoMutations.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { usePhotoMutations } from '../usePhotoMutations';
+
+vi.mock('../api', () => ({
+  deletePhoto: vi.fn().mockResolvedValue(undefined),
+  setPrimaryPhoto: vi.fn().mockResolvedValue({
+    id: 'p-1',
+    url: 'test/photo-gallery.webp',
+    caption: null,
+    is_primary: true,
+    sort_order: 0,
+    status: 'approved',
+  }),
+  reorderPhotos: vi.fn().mockResolvedValue([]),
+  buildPhotoUrl: (url: string) => url,
+  validateFile: () => null,
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(QueryClientProvider, { client: queryClient }, children);
+  };
+}
+
+describe('usePhotoMutations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns deleteMutation, setPrimaryMutation, and reorderMutation', () => {
+    const { result } = renderHook(() => usePhotoMutations('transformers', 'optimus-prime'), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.deleteMutation).toBeDefined();
+    expect(result.current.setPrimaryMutation).toBeDefined();
+    expect(result.current.reorderMutation).toBeDefined();
+  });
+
+  it('deleteMutation calls deletePhoto with correct args', async () => {
+    const { deletePhoto } = await import('../api');
+    const { result } = renderHook(() => usePhotoMutations('transformers', 'optimus-prime'), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.deleteMutation.mutate('photo-1');
+
+    await waitFor(() => {
+      expect(result.current.deleteMutation.isSuccess).toBe(true);
+    });
+
+    expect(deletePhoto).toHaveBeenCalledWith('transformers', 'optimus-prime', 'photo-1');
+  });
+
+  it('setPrimaryMutation calls setPrimaryPhoto with correct args', async () => {
+    const { setPrimaryPhoto } = await import('../api');
+    const { result } = renderHook(() => usePhotoMutations('transformers', 'optimus-prime'), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.setPrimaryMutation.mutate('photo-2');
+
+    await waitFor(() => {
+      expect(result.current.setPrimaryMutation.isSuccess).toBe(true);
+    });
+
+    expect(setPrimaryPhoto).toHaveBeenCalledWith('transformers', 'optimus-prime', 'photo-2');
+  });
+
+  it('reorderMutation calls reorderPhotos with correct args', async () => {
+    const { reorderPhotos } = await import('../api');
+    const { result } = renderHook(() => usePhotoMutations('transformers', 'optimus-prime'), {
+      wrapper: createWrapper(),
+    });
+
+    const newOrder = [
+      { id: 'p-2', sort_order: 0 },
+      { id: 'p-1', sort_order: 1 },
+    ];
+    result.current.reorderMutation.mutate(newOrder);
+
+    await waitFor(() => {
+      expect(result.current.reorderMutation.isSuccess).toBe(true);
+    });
+
+    expect(reorderPhotos).toHaveBeenCalledWith('transformers', 'optimus-prime', newOrder);
+  });
+});

--- a/web/src/catalog/photos/__tests__/usePhotoUpload.test.ts
+++ b/web/src/catalog/photos/__tests__/usePhotoUpload.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { usePhotoUpload } from '../usePhotoUpload';
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+const mockUploadPhoto = vi.fn();
+vi.mock('../api', () => ({
+  uploadPhoto: (...args: unknown[]) => mockUploadPhoto(...args),
+  validateFile: (file: File) => {
+    if (file.type === 'image/tiff') return `${file.name} is not a supported image format`;
+    if (file.size > 10 * 1024 * 1024) return `${file.name} exceeds the 10 MB limit`;
+    return null;
+  },
+  buildPhotoUrl: (url: string) => url,
+}));
+
+function makeFile(name: string, type = 'image/jpeg', size = 1024): File {
+  const blob = new Blob(['x'.repeat(size)], { type });
+  return new File([blob], name, { type });
+}
+
+describe('usePhotoUpload', () => {
+  const onUploadComplete = vi.fn();
+  const defaultOpts = { franchise: 'transformers', itemSlug: 'optimus-prime', onUploadComplete };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUploadPhoto.mockResolvedValue([
+      { id: 'p-1', url: 'test.webp', caption: null, is_primary: false, sort_order: 0, status: 'approved' },
+    ]);
+  });
+
+  it('starts with empty items and isUploading false', () => {
+    const { result } = renderHook(() => usePhotoUpload(defaultOpts));
+
+    expect(result.current.items).toHaveLength(0);
+    expect(result.current.isUploading).toBe(false);
+  });
+
+  it('enqueues valid files', () => {
+    const { result } = renderHook(() => usePhotoUpload(defaultOpts));
+
+    act(() => {
+      result.current.uploadFiles([makeFile('photo1.jpg'), makeFile('photo2.jpg')]);
+    });
+
+    expect(result.current.items).toHaveLength(2);
+    expect(result.current.items[0].fileName).toBe('photo1.jpg');
+    expect(result.current.items[1].fileName).toBe('photo2.jpg');
+  });
+
+  it('rejects invalid MIME type with toast.error', async () => {
+    const { toast } = await import('sonner');
+    const { result } = renderHook(() => usePhotoUpload(defaultOpts));
+
+    act(() => {
+      result.current.uploadFiles([makeFile('bad.tiff', 'image/tiff')]);
+    });
+
+    expect(result.current.items).toHaveLength(0);
+    expect(toast.error).toHaveBeenCalledWith('bad.tiff is not a supported image format');
+  });
+
+  it('processes upload and calls onUploadComplete on success', async () => {
+    const { result } = renderHook(() => usePhotoUpload(defaultOpts));
+
+    act(() => {
+      result.current.uploadFiles([makeFile('photo.jpg')]);
+    });
+
+    await waitFor(() => {
+      expect(onUploadComplete).toHaveBeenCalled();
+    });
+
+    expect(mockUploadPhoto).toHaveBeenCalledWith(
+      'transformers',
+      'optimus-prime',
+      expect.any(File),
+      expect.any(Function)
+    );
+  });
+
+  it('handles upload error and continues processing next file', async () => {
+    mockUploadPhoto
+      .mockRejectedValueOnce(new Error('Server error'))
+      .mockResolvedValueOnce([
+        { id: 'p-2', url: 'test2.webp', caption: null, is_primary: false, sort_order: 1, status: 'approved' },
+      ]);
+
+    const { result } = renderHook(() => usePhotoUpload(defaultOpts));
+
+    act(() => {
+      result.current.uploadFiles([makeFile('fail.jpg'), makeFile('success.jpg')]);
+    });
+
+    // Wait for both to process — waitFor expects an assertion that throws on failure
+    await waitFor(() => {
+      expect(result.current.items.find((i) => i.fileName === 'fail.jpg')?.status).toBe('error');
+    });
+
+    await waitFor(() => {
+      expect(result.current.items.find((i) => i.fileName === 'success.jpg')?.status).toBe('done');
+    });
+  });
+});

--- a/web/src/catalog/photos/api.ts
+++ b/web/src/catalog/photos/api.ts
@@ -1,0 +1,149 @@
+import { apiFetchJson, apiFetch, throwApiError, API_BASE, attemptRefresh } from '@/lib/api-client';
+import { authStore } from '@/lib/auth-store';
+import {
+  UploadPhotosResponseSchema,
+  SetPrimaryResponseSchema,
+  ReorderPhotosResponseSchema,
+  type PhotoWriteItem,
+} from '@/lib/zod-schemas';
+
+const PHOTO_BASE_URL = import.meta.env.VITE_PHOTO_BASE_URL ?? '';
+
+export function buildPhotoUrl(relativeUrl: string): string {
+  if (!PHOTO_BASE_URL) return relativeUrl;
+  const base = PHOTO_BASE_URL.replace(/\/+$/, '');
+  const path = relativeUrl.replace(/^\/+/, '');
+  return `${base}/${path}`;
+}
+
+const ALLOWED_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
+const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
+
+export function validateFile(file: File): string | null {
+  if (!ALLOWED_MIME_TYPES.includes(file.type)) {
+    return `${file.name} is not a supported image format`;
+  }
+  if (file.size > MAX_FILE_SIZE_BYTES) {
+    return `${file.name} exceeds the 10 MB limit`;
+  }
+  return null;
+}
+
+function photoPath(franchise: string, slug: string): string {
+  return `/catalog/franchises/${encodeURIComponent(franchise)}/items/${encodeURIComponent(slug)}/photos`;
+}
+
+export interface UploadProgress {
+  percent: number;
+}
+
+export function uploadPhoto(
+  franchise: string,
+  slug: string,
+  file: File,
+  onProgress: (p: UploadProgress) => void
+): Promise<PhotoWriteItem[]> {
+  return doUpload(franchise, slug, file, onProgress, false);
+}
+
+function doUpload(
+  franchise: string,
+  slug: string,
+  file: File,
+  onProgress: (p: UploadProgress) => void,
+  isRetry: boolean
+): Promise<PhotoWriteItem[]> {
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    xhr.open('POST', `${API_BASE}${photoPath(franchise, slug)}`);
+    xhr.withCredentials = true;
+
+    const token = authStore.getToken();
+    if (token) {
+      xhr.setRequestHeader('Authorization', `Bearer ${token}`);
+    }
+
+    xhr.upload.onprogress = (e) => {
+      if (e.lengthComputable) {
+        onProgress({ percent: Math.round((e.loaded / e.total) * 100) });
+      }
+    };
+
+    xhr.onload = () => {
+      if (xhr.status === 201) {
+        try {
+          const json: unknown = JSON.parse(xhr.responseText);
+          const parsed = UploadPhotosResponseSchema.parse(json);
+          resolve(parsed.photos);
+        } catch {
+          reject(new Error('Invalid upload response'));
+        }
+        return;
+      }
+
+      if (xhr.status === 401 && !isRetry) {
+        void attemptRefresh()
+          .then((refreshed) => {
+            if (refreshed) {
+              doUpload(franchise, slug, file, onProgress, true).then(resolve, reject);
+            } else {
+              reject(new Error('Authentication failed'));
+            }
+          })
+          .catch((e: unknown) => {
+            reject(e instanceof Error ? e : new Error('Auth refresh error'));
+          });
+        return;
+      }
+
+      reject(new Error(extractErrorMessage(xhr.responseText, xhr.status)));
+    };
+
+    xhr.onerror = () => reject(new Error('Network error during upload'));
+
+    const fd = new FormData();
+    fd.append('file', file);
+    xhr.send(fd);
+  });
+}
+
+function extractErrorMessage(responseText: string, status: number): string {
+  try {
+    const raw: unknown = JSON.parse(responseText);
+    if (typeof raw === 'object' && raw !== null && 'error' in raw) {
+      const { error } = raw as { error: unknown };
+      if (typeof error === 'string') return error;
+    }
+  } catch {
+    // fall through to default
+  }
+  return `Upload failed (${status})`;
+}
+
+export async function deletePhoto(franchise: string, slug: string, photoId: string): Promise<void> {
+  const response = await apiFetch(`${photoPath(franchise, slug)}/${encodeURIComponent(photoId)}`, {
+    method: 'DELETE',
+  });
+  if (!response.ok) await throwApiError(response);
+}
+
+export async function setPrimaryPhoto(franchise: string, slug: string, photoId: string): Promise<PhotoWriteItem> {
+  const result = await apiFetchJson(
+    `${photoPath(franchise, slug)}/${encodeURIComponent(photoId)}/primary`,
+    SetPrimaryResponseSchema,
+    { method: 'PATCH' }
+  );
+  return result.photo;
+}
+
+export async function reorderPhotos(
+  franchise: string,
+  slug: string,
+  photos: Array<{ id: string; sort_order: number }>
+): Promise<PhotoWriteItem[]> {
+  const result = await apiFetchJson(`${photoPath(franchise, slug)}/reorder`, ReorderPhotosResponseSchema, {
+    method: 'PATCH',
+    body: JSON.stringify({ photos }),
+  });
+  return result.photos;
+}

--- a/web/src/catalog/photos/usePhotoMutations.ts
+++ b/web/src/catalog/photos/usePhotoMutations.ts
@@ -1,0 +1,30 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { deletePhoto, setPrimaryPhoto, reorderPhotos } from './api';
+import type { PhotoWriteItem } from '@/lib/zod-schemas';
+
+export function usePhotoMutations(franchise: string, slug: string) {
+  const queryClient = useQueryClient();
+
+  const invalidateItem = () => {
+    void queryClient.invalidateQueries({ queryKey: ['catalog', 'items', franchise, slug] });
+  };
+
+  const deleteMutation = useMutation<void, Error, string>({
+    mutationFn: (photoId) => deletePhoto(franchise, slug, photoId),
+    onSuccess: invalidateItem,
+  });
+
+  const setPrimaryMutation = useMutation<PhotoWriteItem, Error, string>({
+    mutationFn: (photoId) => setPrimaryPhoto(franchise, slug, photoId),
+    onSuccess: invalidateItem,
+  });
+
+  const reorderMutation = useMutation<PhotoWriteItem[], Error, Array<{ id: string; sort_order: number }>>({
+    mutationFn: (photos) => reorderPhotos(franchise, slug, photos),
+    onSuccess: invalidateItem,
+  });
+
+  return { deleteMutation, setPrimaryMutation, reorderMutation };
+}
+
+export type PhotoMutations = ReturnType<typeof usePhotoMutations>;

--- a/web/src/catalog/photos/usePhotoUpload.ts
+++ b/web/src/catalog/photos/usePhotoUpload.ts
@@ -1,0 +1,125 @@
+import { useCallback, useEffect, useReducer, useRef } from 'react';
+import { uploadPhoto, validateFile } from './api';
+import { toast } from 'sonner';
+
+export type UploadItemStatus = 'queued' | 'uploading' | 'done' | 'error';
+
+export interface UploadItem {
+  id: string;
+  fileName: string;
+  status: UploadItemStatus;
+  progress: number;
+  errorMessage?: string;
+}
+
+type Action =
+  | { type: 'ENQUEUE'; items: Array<{ id: string; fileName: string }> }
+  | { type: 'START'; id: string }
+  | { type: 'PROGRESS'; id: string; percent: number }
+  | { type: 'DONE'; id: string }
+  | { type: 'ERROR'; id: string; message: string }
+  | { type: 'REMOVE'; id: string };
+
+function reducer(state: UploadItem[], action: Action): UploadItem[] {
+  switch (action.type) {
+    case 'ENQUEUE':
+      return [
+        ...state,
+        ...action.items.map((item) => ({
+          id: item.id,
+          fileName: item.fileName,
+          status: 'queued' as const,
+          progress: 0,
+        })),
+      ];
+    case 'START':
+      return state.map((item) => (item.id === action.id ? { ...item, status: 'uploading' as const } : item));
+    case 'PROGRESS':
+      return state.map((item) => (item.id === action.id ? { ...item, progress: action.percent } : item));
+    case 'DONE':
+      return state.map((item) => (item.id === action.id ? { ...item, status: 'done' as const, progress: 100 } : item));
+    case 'ERROR':
+      return state.map((item) =>
+        item.id === action.id ? { ...item, status: 'error' as const, errorMessage: action.message } : item
+      );
+    case 'REMOVE':
+      return state.filter((item) => item.id !== action.id);
+    default:
+      return state;
+  }
+}
+
+interface UsePhotoUploadOptions {
+  franchise: string;
+  itemSlug: string;
+  onUploadComplete: () => void;
+}
+
+export interface UsePhotoUploadReturn {
+  items: UploadItem[];
+  isUploading: boolean;
+  uploadFiles: (files: File[]) => void;
+}
+
+export function usePhotoUpload({ franchise, itemSlug, onUploadComplete }: UsePhotoUploadOptions): UsePhotoUploadReturn {
+  const [items, dispatch] = useReducer(reducer, []);
+  const isUploading = items.some((item) => item.status === 'uploading');
+  const processingRef = useRef(false);
+  const filesMapRef = useRef(new Map<string, File>());
+
+  const uploadFiles = useCallback((files: File[]) => {
+    const validItems: Array<{ id: string; fileName: string }> = [];
+
+    for (const file of files) {
+      const error = validateFile(file);
+      if (error) {
+        toast.error(error);
+        continue;
+      }
+      const id = crypto.randomUUID();
+      filesMapRef.current.set(id, file);
+      validItems.push({ id, fileName: file.name });
+    }
+
+    if (validItems.length > 0) {
+      dispatch({ type: 'ENQUEUE', items: validItems });
+    }
+  }, []);
+
+  useEffect(() => {
+    if (processingRef.current) return;
+
+    const nextQueued = items.find((item) => item.status === 'queued');
+    if (!nextQueued) return;
+
+    const file = filesMapRef.current.get(nextQueued.id);
+    if (!file) return;
+
+    processingRef.current = true;
+    dispatch({ type: 'START', id: nextQueued.id });
+
+    uploadPhoto(franchise, itemSlug, file, (p) => {
+      dispatch({ type: 'PROGRESS', id: nextQueued.id, percent: p.percent });
+    })
+      .then(() => {
+        processingRef.current = false;
+        dispatch({ type: 'DONE', id: nextQueued.id });
+        filesMapRef.current.delete(nextQueued.id);
+        toast.success(`${nextQueued.fileName} uploaded`);
+        onUploadComplete();
+
+        setTimeout(() => {
+          dispatch({ type: 'REMOVE', id: nextQueued.id });
+        }, 3000);
+      })
+      .catch((err: unknown) => {
+        processingRef.current = false;
+        const message = err instanceof Error ? err.message : 'Upload failed';
+        dispatch({ type: 'ERROR', id: nextQueued.id, message });
+        filesMapRef.current.delete(nextQueued.id);
+        toast.error(`Failed to upload ${nextQueued.fileName}`);
+      });
+  }, [items, franchise, itemSlug, onUploadComplete]);
+
+  return { items, isUploading, uploadFiles };
+}

--- a/web/src/components/ui/sheet.tsx
+++ b/web/src/components/ui/sheet.tsx
@@ -1,0 +1,106 @@
+import * as React from 'react';
+import * as SheetPrimitive from '@radix-ui/react-dialog';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { X } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+const Sheet = SheetPrimitive.Root;
+
+const SheetTrigger = SheetPrimitive.Trigger;
+
+const SheetClose = SheetPrimitive.Close;
+
+const SheetPortal = SheetPrimitive.Portal;
+
+const SheetOverlay = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Overlay
+    className={cn(
+      'fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      className
+    )}
+    {...props}
+    ref={ref}
+  />
+));
+SheetOverlay.displayName = SheetPrimitive.Overlay.displayName;
+
+const sheetVariants = cva(
+  'fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500',
+  {
+    variants: {
+      side: {
+        top: 'inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top',
+        bottom:
+          'inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom',
+        left: 'inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm',
+        right:
+          'inset-y-0 right-0 h-full w-3/4  border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm',
+      },
+    },
+    defaultVariants: {
+      side: 'right',
+    },
+  }
+);
+
+interface SheetContentProps
+  extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>, VariantProps<typeof sheetVariants> {}
+
+const SheetContent = React.forwardRef<React.ElementRef<typeof SheetPrimitive.Content>, SheetContentProps>(
+  ({ side = 'right', className, children, ...props }, ref) => (
+    <SheetPortal>
+      <SheetOverlay />
+      <SheetPrimitive.Content ref={ref} className={cn(sheetVariants({ side }), className)} {...props}>
+        {children}
+        <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+          <X className="h-4 w-4" />
+          <span className="sr-only">Close</span>
+        </SheetPrimitive.Close>
+      </SheetPrimitive.Content>
+    </SheetPortal>
+  )
+);
+SheetContent.displayName = SheetPrimitive.Content.displayName;
+
+const SheetHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex flex-col space-y-2 text-center sm:text-left', className)} {...props} />
+);
+SheetHeader.displayName = 'SheetHeader';
+
+const SheetFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)} {...props} />
+);
+SheetFooter.displayName = 'SheetFooter';
+
+const SheetTitle = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Title ref={ref} className={cn('text-lg font-semibold text-foreground', className)} {...props} />
+));
+SheetTitle.displayName = SheetPrimitive.Title.displayName;
+
+const SheetDescription = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Description ref={ref} className={cn('text-sm text-muted-foreground', className)} {...props} />
+));
+SheetDescription.displayName = SheetPrimitive.Description.displayName;
+
+export {
+  Sheet,
+  SheetPortal,
+  SheetOverlay,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+};

--- a/web/src/lib/api-client.ts
+++ b/web/src/lib/api-client.ts
@@ -65,6 +65,7 @@ function buildHeaders(url: string, init?: RequestInit): Headers {
     init?.method &&
     ['POST', 'PUT', 'PATCH'].includes(init.method.toUpperCase()) &&
     init.body !== undefined &&
+    !(init.body instanceof FormData) &&
     !headers.has('Content-Type')
   ) {
     headers.set('Content-Type', 'application/json');

--- a/web/src/lib/zod-schemas.ts
+++ b/web/src/lib/zod-schemas.ts
@@ -155,6 +155,32 @@ export const CatalogItemDetailSchema = CatalogItemSchema.extend({
   updated_at: z.string(),
 });
 
+// Photo read shape — extracted from CatalogItemDetailSchema for reuse
+export const PhotoSchema = CatalogItemDetailSchema.shape.photos.element;
+
+// Photo write response (POST upload, PATCH primary, PATCH reorder)
+// Includes status field returned by curator-facing endpoints
+export const PhotoWriteItemSchema = z.object({
+  id: z.string(),
+  url: z.string(),
+  caption: z.string().nullable(),
+  is_primary: z.boolean(),
+  sort_order: z.number().int(),
+  status: z.enum(['pending', 'approved', 'rejected']),
+});
+
+export const UploadPhotosResponseSchema = z.object({
+  photos: z.array(PhotoWriteItemSchema),
+});
+
+export const SetPrimaryResponseSchema = z.object({
+  photo: PhotoWriteItemSchema,
+});
+
+export const ReorderPhotosResponseSchema = z.object({
+  photos: z.array(PhotoWriteItemSchema),
+});
+
 // Facet counts (GET /catalog/franchises/:franchise/items/facets)
 export const FacetValueSchema = z.object({
   value: z.string(),
@@ -373,3 +399,5 @@ export type ManufacturerDetail = z.infer<typeof ManufacturerDetailSchema>;
 export type ManufacturerStatsItem = z.infer<typeof ManufacturerStatsItemSchema>;
 export type ManufacturerStatsList = z.infer<typeof ManufacturerStatsListSchema>;
 export type ManufacturerItemFacets = z.infer<typeof ManufacturerItemFacetsSchema>;
+export type Photo = z.infer<typeof PhotoSchema>;
+export type PhotoWriteItem = z.infer<typeof PhotoWriteItemSchema>;

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -5,6 +5,7 @@ interface ImportMetaEnv {
   readonly VITE_GOOGLE_CLIENT_ID: string
   readonly VITE_APPLE_SERVICES_ID: string
   readonly VITE_APPLE_REDIRECT_URI: string
+  readonly VITE_PHOTO_BASE_URL: string
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary

- **Photo management Sheet** for curators: drag-and-drop upload with XHR progress bars, `@dnd-kit` sortable grid (full-tile drag surface), primary photo badge, delete with confirmation
- **Photo gallery improvements**: two-level interaction (thumbnails select in-page, main image click opens lightbox), wrapping nav, ZoomIn icon overlay, `object-contain` across all photo displays, `max-h-[32rem]` main image constraint
- **Sort consistency**: gallery sorts `is_primary DESC, sort_order ASC` matching API query — fixes primary photo appearing out of position after set-primary mutations
- Integration with `ItemDetailPage` and `ItemDetailPanel` (camera icon, curator role-gated)

## Test plan

- [x] PhotoGallery unit tests (13 tests): thumbnail selection, lightbox open at selected index, wrap-around navigation, magnifying glass icon
- [x] PhotoGrid unit tests (11 tests): rendering, set primary, delete callback, help text
- [x] PhotoManagementSheet, DropZone, UploadQueue, usePhotoUpload, usePhotoMutations, api unit tests
- [x] Updated test scenarios in `docs/test-scenarios/E2E_CATALOG_DETAIL_PAGES.md`
- [x] Updated design doc, ADR, and `web/CLAUDE.md`
- [x] Manual: verify photo upload, reorder, set primary, delete in dev environment
- [x] Manual: verify gallery thumbnail order matches manager order after reorder/set-primary

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)