### PR TITLE
feat(ml): add --source-dir mode for training data preparation

### DIFF
--- a/changelog/2026-03-22T221419Z_ml-source-dir-scan.md
+++ b/changelog/2026-03-22T221419Z_ml-source-dir-scan.md
@@ -1,0 +1,110 @@
+# ML Training Data — Directory Scan Mode
+
+**Date:** 2026-03-22
+**Time:** 22:14:19 UTC
+**Type:** Feature
+**Phase:** 4.0a
+
+## Summary
+
+Added `--source-dir` as an alternative input mode to the ML training data preparation pipeline, allowing direct scanning of a seed-images directory tree instead of requiring an API manifest export. This supports larger-scale training from curated image collections organized by tier (`catalog/` and `training-only/`), franchise, manufacturer, and item.
+
+---
+
+## Changes Implemented
+
+### 1. Directory Scanner Module
+
+New `scan.ts` module walks a seed-images directory tree with the structure `{tier}/{franchise}/{manufacturer}/{item}/{images}` and produces a `Manifest` object compatible with the existing pipeline — no changes needed to augmentation, copy, or validation modules.
+
+**Created:**
+
+- `ml/src/scan.ts` — Directory tree scanner, merges `catalog/` and `training-only/` tiers, skips `_unmatched/`
+- `ml/src/scan.test.ts` — 8 tests covering tier merging, label format, skip rules, missing tiers, error cases
+
+### 2. CLI Integration
+
+Updated the CLI entry point to accept `--source-dir` as a mutually exclusive alternative to `--manifest`. The `CliOptions` type now uses a discriminated union (`CliSource`) for the input mode.
+
+**Modified:**
+
+- `ml/src/prepare-training-data.ts` — Added `--source-dir` flag, updated usage text, source-mode logging
+- `ml/src/types.ts` — Added `CliSource` discriminated union, updated `CliOptions`
+
+### 3. Documentation Updates
+
+**Modified:**
+
+- `ml/README.md` — Full rewrite reflecting actual pipeline modules, both input modes, seed-images structure, CLI options
+- `ml/CLAUDE.md` — Updated Training Data Source section, Build Commands, and Augmentation notes
+- `docs/decisions/ADR_ML_Training_Data_Preparation.md` — Added 2026-03-22 extension section, `scan.ts` in module list
+- `docs/plans/Development_Roadmap_v1_0.md` — Phase 4.0a marked DONE, critical path table updated
+- `docs/test-scenarios/UNIT_ML_TRAINING_DATA.md` — Added 6 Gherkin scenarios for directory scanning
+
+---
+
+## Technical Details
+
+### Seed-Images Directory Structure
+
+```
+{source-dir}/
+  catalog/                          # API-importable reference photos
+    {franchise}/{manufacturer}/{item}/{images}
+  training-only/                    # ML training only
+    {franchise}/{manufacturer}/{item}/{images}
+  _unmatched/                       # Ignored by tooling
+```
+
+### Adapter Pattern
+
+`scanSourceDir()` returns the same `Manifest` type as `readManifest()`, so the downstream pipeline (balance → augment → copy → validate) required zero changes. Both tiers are merged naturally by `groupEntriesByLabel()` since entries from both tiers share the same `franchise/item` label.
+
+### Usage
+
+```bash
+npm run prepare-data -- --source-dir "/path/to/test-images" --output "/path/to/output"
+npm run prepare-data -- --source-dir "/path/to/test-images" --classes transformers/r-03-bovis
+```
+
+---
+
+## Validation & Testing
+
+```
+ Test Files  7 passed (7)
+      Tests  87 passed (87)
+   Duration  254ms
+```
+
+TypeScript: zero errors (`npm run typecheck` clean).
+
+---
+
+## Impact Assessment
+
+- Training data preparation no longer requires the API server to be running — images can be processed directly from disk
+- Supports the curated seed-images collection on the external drive (293 items, 3,048 matched images across 5 manufacturers)
+- The `catalog/` vs `training-only/` tier split enables a future API import workflow that only ingests catalog-quality images
+
+---
+
+## Related Files
+
+| File | Change |
+|---|---|
+| `ml/src/scan.ts` | Created |
+| `ml/src/scan.test.ts` | Created |
+| `ml/src/prepare-training-data.ts` | Modified |
+| `ml/src/types.ts` | Modified |
+| `ml/CLAUDE.md` | Modified |
+| `ml/README.md` | Modified |
+| `docs/decisions/ADR_ML_Training_Data_Preparation.md` | Modified |
+| `docs/plans/Development_Roadmap_v1_0.md` | Modified |
+| `docs/test-scenarios/UNIT_ML_TRAINING_DATA.md` | Modified |
+
+---
+
+## Status
+
+✅ COMPLETE

--- a/docs/decisions/ADR_ML_Training_Data_Preparation.md
+++ b/docs/decisions/ADR_ML_Training_Data_Preparation.md
@@ -2,13 +2,17 @@
 
 ## Status
 
-Implemented (2026-03-21)
+Implemented (2026-03-21), extended (2026-03-22)
 
 ## Context
 
 Phase 4.0a of the roadmap requires a training data preparation pipeline that bridges the existing ML export endpoint (`POST /catalog/ml-export`, Phase 1.9 Slice 3) and Create ML model training (Phase 4.0b). The ML export endpoint already generates manifest JSON files with photo paths and labels. The pipeline needs to transform this manifest into Create ML's expected folder-per-class structure with augmented images.
 
 Two test classes are available: Commander Stack (18 photos) and Margh (19 photos), both Transformers items.
+
+### 2026-03-22 Extension: Directory Scan Mode
+
+A `--source-dir` flag was added as an alternative to `--manifest`, allowing the pipeline to scan a seed-images directory tree directly instead of requiring an API export. This supports larger-scale training from curated image collections stored on external drives, organized as `{tier}/{franchise}/{manufacturer}/{item}/{images}`. Two tiers (`catalog/` and `training-only/`) are merged per item. Directories named `_unmatched/` are skipped.
 
 ## Decision
 
@@ -23,7 +27,8 @@ The `ml/` module gets its own `package.json` as a standalone Node.js project (no
 - `src/augment.ts` — Augmentation orchestrator (adaptive target-based)
 - `src/copy.ts` — File copy operations with idempotency
 - `src/validate.ts` — Output structure validation against Create ML format
-- `src/prepare-training-data.ts` — CLI entry point
+- `src/scan.ts` — Directory tree scanner (produces Manifest from seed-images directory)
+- `src/prepare-training-data.ts` — CLI entry point (supports `--manifest` or `--source-dir`)
 
 Each module (except entry point and types) has a companion `.test.ts` file.
 
@@ -61,6 +66,7 @@ Training data is written to `ML_TRAINING_DATA_PATH` (new env var), pointing to t
 - **Python/PIL**: Richer ML ecosystem but adds a new language dependency. Node.js/sharp keeps the toolchain unified.
 - **Symlinks instead of copies**: Less disk usage but breaks portability across machines.
 - **Database-direct queries**: Would eliminate the manifest intermediary but couples the ML pipeline to the API's database.
+- **Directory scan only (no manifest mode)**: Simpler but loses the ability to leverage API filters (franchise, search query, approval status). Both modes are retained for different workflows.
 
 ## Consequences
 

--- a/docs/plans/Development_Roadmap_v1_0.md
+++ b/docs/plans/Development_Roadmap_v1_0.md
@@ -71,7 +71,7 @@ The project has completed its authentication foundation (Phases 1.1–1.3) and i
 | Catalog API Routes            | NOT STARTED       | Blocked by seed ingestion                  |
 | Web Catalog UI                | NOT STARTED       | Blocked by catalog API                     |
 | Photo Upload API + UI         | NOT STARTED       | Schema exists (`item_photos`), no app code |
-| ML Training Pipeline          | NOT STARTED       | Blocked by photo data                      |
+| ML Training Pipeline          | 4.0a DONE         | 4.0b ready (training data prep complete)   |
 | iOS App + On-Device Inference | NOT STARTED       | Blocked by trained model                   |
 
 ### What's Deferred (Post-ML)
@@ -289,12 +289,14 @@ Train image classification models using the collector's own catalog photos.
 
 **Sub-phases:**
 
-#### 4.0a: Training Data Preparation
+#### 4.0a: Training Data Preparation — DONE
 
-- Export script: pull labeled photos from DB/storage, organize into `ClassName/` folder structure
-- Data augmentation strategy (rotation, scale, brightness variations)
-- Class balance analysis (identify under-represented classes)
-- Minimum viable class set: start with the most-photographed characters/items
+- ✅ Export script with two input modes: API manifest (`--manifest`) and directory scan (`--source-dir`)
+- ✅ Data augmentation: 15 deterministic transforms (flip, rotation ±10°, brightness ±20%, compounds)
+- ✅ Class balance analysis with adaptive augmentation (target count per class, default 100)
+- ✅ Seed-images directory structure: `{tier}/{franchise}/{manufacturer}/{item}/` with `catalog/` and `training-only/` tiers
+- ✅ Output validation: Create ML format, minimum 10 images per class, clean-on-rerun
+- ✅ 87 unit tests across 7 test files
 
 #### 4.0b: Model Training (macOS)
 

--- a/docs/test-scenarios/UNIT_ML_TRAINING_DATA.md
+++ b/docs/test-scenarios/UNIT_ML_TRAINING_DATA.md
@@ -7,6 +7,66 @@ And a valid manifest JSON exists with photo entries
 
 ## Scenarios
 
+### Directory Scanning
+
+#### Happy Path: Scan both tiers
+
+```gherkin
+Scenario: Discover images from catalog and training-only tiers
+  Given a source directory with catalog/ and training-only/ tiers
+  And catalog/transformers/mmc/r-03-bovis/ has 3 images
+  And training-only/transformers/mmc/r-03-bovis/ has 2 images
+  When scanSourceDir is called
+  Then it returns a Manifest with 5 entries for label "transformers/r-03-bovis"
+```
+
+#### Happy Path: Correct label format
+
+```gherkin
+Scenario: Labels use franchise/item-slug format
+  Given a source directory with catalog/transformers/fanstoys/ft-04-scoria/ containing 1 image
+  When scanSourceDir is called
+  Then the entry label is "transformers/ft-04-scoria"
+  And franchise_slug is "transformers"
+  And item_slug is "ft-04-scoria"
+```
+
+#### Skip: Unmatched directories ignored
+
+```gherkin
+Scenario: _unmatched directories are skipped
+  Given a source directory with _unmatched/ containing images
+  When scanSourceDir is called
+  Then no entries reference _unmatched paths
+```
+
+#### Skip: Non-image files ignored
+
+```gherkin
+Scenario: Non-image files in item directories are skipped
+  Given an item directory containing both .jpeg and .txt files
+  When scanSourceDir is called
+  Then only .jpeg entries are included
+```
+
+#### Error: Empty source directory
+
+```gherkin
+Scenario: Throw when no images found
+  Given an empty source directory
+  When scanSourceDir is called
+  Then it throws an error mentioning "No images found"
+```
+
+#### Graceful: Missing tier
+
+```gherkin
+Scenario: Missing training-only tier does not cause failure
+  Given a source directory with only catalog/ (no training-only/)
+  When scanSourceDir is called
+  Then it returns entries from catalog/ only
+```
+
 ### Manifest Parsing
 
 #### Happy Path: Valid manifest parses correctly

--- a/ml/CLAUDE.md
+++ b/ml/CLAUDE.md
@@ -15,7 +15,13 @@
 
 - ML training uses **catalog photos** from the `item_photos` table (shared, app-managed reference images)
 - Catalog photos are NOT user-private PII — no consent mechanism needed
-- Training data export: `npm run prepare-data -- --manifest <path>` reads API manifest, copies photos into `ClassName/` folders at `ML_TRAINING_DATA_PATH`
+- Two input modes (mutually exclusive):
+  - `npm run prepare-data -- --manifest <path>` — reads API export manifest JSON
+  - `npm run prepare-data -- --source-dir <path>` — scans seed-images directory tree directly
+- Seed-images structure: `{sourceDir}/{tier}/{franchise}/{manufacturer}/{item}/{images}` where tier is `catalog/` or `training-only/`
+- `catalog/` images are API-importable reference photos; `training-only/` images are for ML training only
+- Both tiers are merged per item during training data preparation
+- `_unmatched/` directories are skipped at any level
 - User collection photos (private, RLS-protected) are NOT used for training
 
 ## Phase 4.0 Pipeline (planned)
@@ -150,7 +156,8 @@ Each subdirectory name becomes a class label in the trained model.
 
 ```bash
 cd ml && npm install           # Install dependencies (sharp, tsx, typescript)
-cd ml && npm run prepare-data -- --manifest <path>  # Prepare training data
+cd ml && npm run prepare-data -- --manifest <path>     # Prepare from API manifest
+cd ml && npm run prepare-data -- --source-dir <path>   # Prepare from seed-images directory
 cd ml && npm test              # Run tests + lint
 cd ml && npm run typecheck     # TypeScript check only
 cd ml && npm run lint          # ESLint only
@@ -160,7 +167,7 @@ cd ml && npm run format:check  # Prettier check (CI mode)
 
 ### Augmentation
 
-- Transforms are deterministic (no randomness) — same manifest + target produces identical output
+- Transforms are deterministic (no randomness) — same input (manifest or source-dir) + target produces identical output
 - Adaptive: classes with fewer originals get more augmentation to reach the target count
 - Compound transforms: flip+rotate, flip+brightness, etc. for diversity
 - Clean-on-rerun: class directories are wiped before repopulating to prevent orphans

--- a/ml/README.md
+++ b/ml/README.md
@@ -4,16 +4,74 @@ On-device toy image classification using Core ML and Create ML with transfer lea
 
 ## Status
 
-Early stage. Training data structure and pipeline conventions are defined; model training has not yet started.
+Phase 4.0a (Training Data Preparation) is implemented. The pipeline supports two input modes: API manifest export and direct directory scanning of seed images. Model training (Phase 4.0b) is next.
 
 ## Directory Structure
 
 ```
 ml/
-├── training-data/    # Labeled image folders (one per class, Create ML format)
-├── models/           # Trained .mlmodel output files
-├── TRAINING.md       # Training pipeline conventions and requirements
-└── CLAUDE.md         # Agent rules for this module
+├── src/
+│   ├── prepare-training-data.ts  # CLI entry point (5-step pipeline)
+│   ├── scan.ts                   # Directory scanner for seed images
+│   ├── manifest.ts               # Manifest JSON parser + label utilities
+│   ├── balance.ts                # Class balance analysis and reporting
+│   ├── transforms.ts             # 15 deterministic augmentation transforms
+│   ├── augment.ts                # Adaptive augmentation orchestrator
+│   ├── copy.ts                   # File copy with idempotency + clean-on-rerun
+│   ├── validate.ts               # Output validation (Create ML format)
+│   ├── types.ts                  # Shared interfaces
+│   └── *.test.ts                 # Companion tests for each module
+├── models/                       # Trained .mlmodel output files
+└── CLAUDE.md                     # Agent rules for this module
+```
+
+## Training Data Preparation
+
+Two mutually exclusive input modes:
+
+```bash
+# From API manifest (exported by POST /catalog/ml-export)
+npm run prepare-data -- --manifest <path>
+
+# From seed-images directory (catalog/ + training-only/ tiers)
+npm run prepare-data -- --source-dir <path>
+```
+
+### Seed Images Directory Structure
+
+```
+{source-dir}/
+  catalog/                          # API-importable reference photos
+    {franchise}/
+      {manufacturer}/
+        {item-slug}/
+          image-1.jpeg
+  training-only/                    # ML training only (not catalog-quality)
+    {franchise}/
+      {manufacturer}/
+        {item-slug}/
+          image-2.jpeg
+  _unmatched/                       # Ignored by tooling
+```
+
+Both tiers are merged per item during preparation. The output is a flat folder-per-class structure for Create ML:
+
+```
+ML_TRAINING_DATA_PATH/
+  {franchise}__{item-slug}/
+    image-1.jpeg                    # Original
+    aug-0-hflip.webp               # Augmented
+    aug-1-rotate-cw.webp
+```
+
+### Common Options
+
+```bash
+--output <path>         # Output directory (default: ML_TRAINING_DATA_PATH env)
+--target-count <n>      # Target images per class (default: 100)
+--format webp|jpeg      # Output image format (default: webp)
+--classes <a,b,c>       # Only process specific labels (comma-separated)
+--no-clean              # Skip cleaning class directories before writing
 ```
 
 ## Constraints
@@ -22,10 +80,19 @@ ml/
 - **Inference:** On-device only via Core ML — no server-side ML calls
 - **Training scripts:** Must be idempotent, use relative paths only, contain no credentials
 - **Training data:** Follows Create ML's `<class-name>/<images>` folder format
+- **Minimum images:** 10 per class (enforced by validation)
+- **Labels:** Use `__` delimiter (e.g., `transformers__ft-04-scoria`) — Create ML requires single-level directories
 
-## Getting Started
+## Build Commands
 
-See [`TRAINING.md`](TRAINING.md) for training script requirements, pipeline rules, and evaluation guidelines.
+```bash
+npm install           # Install dependencies (sharp, tsx, typescript)
+npm test              # Run tests + lint
+npm run typecheck     # TypeScript check only
+npm run lint          # ESLint only
+npm run format        # Prettier format
+npm run format:check  # Prettier check (CI mode)
+```
 
 ## Integration
 

--- a/ml/src/prepare-training-data.ts
+++ b/ml/src/prepare-training-data.ts
@@ -1,6 +1,7 @@
 /**
  * Pipeline: prepare-training-data
- * Input:    ML export manifest JSON (produced by POST /catalog/ml-export)
+ * Input:    ML export manifest JSON  (--manifest <path>)
+ *       OR  Seed-images directory     (--source-dir <path>)
  * Output:   Create ML folder-per-class structure at ML_TRAINING_DATA_PATH
  *           Format: {outputDir}/{franchise__item-slug}/{filename}.webp
  * Time:     ~30s per 1000 photos on Apple Silicon (copy-only), ~2-5min with augmentation
@@ -11,6 +12,7 @@ import { stat } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import type { CliOptions } from './types.js';
 import { readManifest, groupEntriesByLabel, flattenLabel } from './manifest.js';
+import { scanSourceDir } from './scan.js';
 import { analyzeBalance, printBalanceReport } from './balance.js';
 import { TRANSFORMS } from './transforms.js';
 import { augmentClass } from './augment.js';
@@ -26,6 +28,7 @@ const CONCURRENCY_LIMIT = 5;
 function loadCliOptions(): CliOptions {
   const args = process.argv.slice(2);
   let manifestPath: string | undefined;
+  let sourceDir: string | undefined;
   let outputDir: string | undefined = process.env['ML_TRAINING_DATA_PATH'];
   let targetCount = DEFAULT_TARGET_COUNT;
   let format: 'webp' | 'jpeg' = 'webp';
@@ -36,6 +39,8 @@ function loadCliOptions(): CliOptions {
     const arg = args[i];
     if (arg === '--manifest' && i + 1 < args.length) {
       manifestPath = args[++i];
+    } else if (arg === '--source-dir' && i + 1 < args.length) {
+      sourceDir = args[++i];
     } else if (arg === '--output' && i + 1 < args.length) {
       outputDir = args[++i];
     } else if (arg === '--target-count' && i + 1 < args.length) {
@@ -58,16 +63,24 @@ function loadCliOptions(): CliOptions {
       }
     } else if (arg === '--no-clean') {
       noClean = true;
-    } else if (!arg?.startsWith('--') && !manifestPath) {
+    } else if (!arg?.startsWith('--') && !manifestPath && !sourceDir) {
       manifestPath = arg;
     }
   }
 
-  if (!manifestPath) {
-    console.error('Error: manifest path is required');
-    console.error('Usage: npm run prepare-data -- --manifest <path> [options]');
+  if (manifestPath && sourceDir) {
+    console.error('Error: --manifest and --source-dir are mutually exclusive');
+    process.exit(1);
+  }
+
+  if (!manifestPath && !sourceDir) {
+    console.error('Error: either --manifest or --source-dir is required');
+    console.error('Usage:');
+    console.error('  npm run prepare-data -- --manifest <path> [options]');
+    console.error('  npm run prepare-data -- --source-dir <path> [options]');
     console.error('Options:');
-    console.error('  --manifest <path>       Path to ML export manifest JSON (required)');
+    console.error('  --manifest <path>       Path to ML export manifest JSON');
+    console.error('  --source-dir <path>     Path to seed-images directory (catalog/ + training-only/)');
     console.error('  --output <path>         Output directory (default: ML_TRAINING_DATA_PATH env)');
     console.error('  --target-count <n>      Target images per class (default: 100)');
     console.error('  --format webp|jpeg      Output image format (default: webp)');
@@ -82,8 +95,12 @@ function loadCliOptions(): CliOptions {
     process.exit(1);
   }
 
+  const source = manifestPath
+    ? ({ mode: 'manifest' as const, manifestPath: resolve(manifestPath) })
+    : ({ mode: 'source-dir' as const, sourceDir: resolve(sourceDir!) });
+
   return {
-    manifestPath: resolve(manifestPath),
+    source,
     outputDir: resolve(outputDir),
     targetCount,
     format,
@@ -107,7 +124,7 @@ async function processBatch<T>(items: T[], limit: number, fn: (item: T) => Promi
 }
 
 /**
- * Main pipeline: read manifest, analyze balance, copy + augment, validate.
+ * Main pipeline: read manifest or scan source dir, analyze balance, copy + augment, validate.
  */
 async function main(): Promise<void> {
   const startTime = Date.now();
@@ -115,7 +132,12 @@ async function main(): Promise<void> {
 
   console.log('ML Training Data Preparation');
   console.log('═'.repeat(80));
-  console.log(`Manifest:     ${options.manifestPath}`);
+
+  if (options.source.mode === 'manifest') {
+    console.log(`Source:       manifest (${options.source.manifestPath})`);
+  } else {
+    console.log(`Source:       directory scan (${options.source.sourceDir})`);
+  }
   console.log(`Output:       ${options.outputDir}`);
   console.log(`Target/class: ${options.targetCount}`);
   console.log(`Format:       ${options.format}`);
@@ -124,17 +146,24 @@ async function main(): Promise<void> {
     console.log(`Filter:       ${options.classes.join(', ')}`);
   }
 
-  // Check manifest age
-  const manifestStat = await stat(options.manifestPath);
-  const ageMs = Date.now() - manifestStat.mtimeMs;
-  const ageHours = ageMs / (1000 * 60 * 60);
-  if (ageHours > 24) {
-    console.log(`\nWarning: Manifest is ${Math.floor(ageHours)} hours old — consider re-exporting from the API.`);
+  // Step 1: Load manifest (from file or directory scan)
+  console.log('\n[1/5] Loading image sources...');
+  let manifest;
+
+  if (options.source.mode === 'manifest') {
+    // Check manifest age
+    const manifestStat = await stat(options.source.manifestPath);
+    const ageMs = Date.now() - manifestStat.mtimeMs;
+    const ageHours = ageMs / (1000 * 60 * 60);
+    if (ageHours > 24) {
+      console.log(`  Warning: Manifest is ${Math.floor(ageHours)} hours old — consider re-exporting from the API.`);
+    }
+
+    manifest = await readManifest(options.source.manifestPath);
+  } else {
+    manifest = await scanSourceDir(options.source.sourceDir);
   }
 
-  // Step 1: Read manifest
-  console.log('\n[1/5] Reading manifest...');
-  const manifest = await readManifest(options.manifestPath);
   console.log(
     `  Found ${manifest.stats.total_photos} photos across ${manifest.stats.items} items in ${manifest.stats.franchises} franchise(s)`
   );

--- a/ml/src/scan.test.ts
+++ b/ml/src/scan.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { writeFile, mkdir, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomUUID } from 'node:crypto';
+import { scanSourceDir } from './scan.js';
+
+const testRoot = join(tmpdir(), `ml-scan-test-${randomUUID()}`);
+
+/**
+ * Build a realistic seed-images directory tree:
+ *   testRoot/
+ *     catalog/
+ *       transformers/
+ *         mmc/
+ *           r-03-bovis/     (3 images)
+ *           r-04-leo-dux/   (2 images)
+ *         fanstoys/
+ *           ft-04-scoria/   (1 image)
+ *     training-only/
+ *       transformers/
+ *         mmc/
+ *           r-03-bovis/     (2 images — merges with catalog tier)
+ *     _unmatched/
+ *       stray-file.jpg
+ */
+async function buildTree(): Promise<void> {
+  const dirs = [
+    'catalog/transformers/mmc/r-03-bovis',
+    'catalog/transformers/mmc/r-04-leo-dux',
+    'catalog/transformers/fanstoys/ft-04-scoria',
+    'training-only/transformers/mmc/r-03-bovis',
+    '_unmatched',
+  ];
+
+  for (const d of dirs) {
+    await mkdir(join(testRoot, d), { recursive: true });
+  }
+
+  const files: [string, string][] = [
+    ['catalog/transformers/mmc/r-03-bovis/r-03-bovis-1.jpeg', 'img1'],
+    ['catalog/transformers/mmc/r-03-bovis/r-03-bovis-2.jpeg', 'img2'],
+    ['catalog/transformers/mmc/r-03-bovis/r-03-bovis-3.jpeg', 'img3'],
+    ['catalog/transformers/mmc/r-04-leo-dux/r-04-leo-dux-1.png', 'img4'],
+    ['catalog/transformers/mmc/r-04-leo-dux/r-04-leo-dux-2.png', 'img5'],
+    ['catalog/transformers/fanstoys/ft-04-scoria/ft-04-scoria-1.webp', 'img6'],
+    ['training-only/transformers/mmc/r-03-bovis/r-03-bovis-4.jpeg', 'img7'],
+    ['training-only/transformers/mmc/r-03-bovis/r-03-bovis-5.jpeg', 'img8'],
+    ['_unmatched/stray-file.jpg', 'stray'],
+  ];
+
+  for (const [path, content] of files) {
+    await writeFile(join(testRoot, path), content);
+  }
+}
+
+beforeAll(async () => {
+  await buildTree();
+});
+
+afterAll(async () => {
+  await rm(testRoot, { recursive: true, force: true });
+});
+
+describe('scanSourceDir', () => {
+  it('discovers images from both catalog and training-only tiers', async () => {
+    const manifest = await scanSourceDir(testRoot);
+
+    expect(manifest.version).toBe(1);
+    expect(manifest.stats.total_photos).toBe(8);
+    expect(manifest.stats.franchises).toBe(1);
+    expect(manifest.stats.items).toBe(3);
+  });
+
+  it('merges same item across tiers into the same label', async () => {
+    const manifest = await scanSourceDir(testRoot);
+
+    const bovisEntries = manifest.entries.filter((e) => e.label === 'transformers/r-03-bovis');
+    expect(bovisEntries).toHaveLength(5); // 3 catalog + 2 training-only
+  });
+
+  it('produces correct label format', async () => {
+    const manifest = await scanSourceDir(testRoot);
+
+    const labels = new Set(manifest.entries.map((e) => e.label));
+    expect(labels).toEqual(
+      new Set(['transformers/r-03-bovis', 'transformers/r-04-leo-dux', 'transformers/ft-04-scoria'])
+    );
+  });
+
+  it('sets photo_path to absolute file paths', async () => {
+    const manifest = await scanSourceDir(testRoot);
+
+    for (const entry of manifest.entries) {
+      expect(entry.photo_path).toContain(testRoot);
+      expect(entry.photo_path).toMatch(/\.(jpeg|jpg|png|webp|heic)$/);
+    }
+  });
+
+  it('populates franchise_slug and item_slug correctly', async () => {
+    const manifest = await scanSourceDir(testRoot);
+
+    const scoria = manifest.entries.find((e) => e.item_slug === 'ft-04-scoria');
+    expect(scoria).toBeDefined();
+    expect(scoria!.franchise_slug).toBe('transformers');
+    expect(scoria!.item_name).toBe('ft-04-scoria');
+  });
+
+  it('skips _unmatched directories', async () => {
+    const manifest = await scanSourceDir(testRoot);
+
+    const stray = manifest.entries.find((e) => e.photo_path.includes('_unmatched'));
+    expect(stray).toBeUndefined();
+  });
+
+  it('skips non-image files', async () => {
+    // Add a non-image file to a valid item directory
+    await writeFile(join(testRoot, 'catalog/transformers/mmc/r-03-bovis/notes.txt'), 'not an image');
+
+    const manifest = await scanSourceDir(testRoot);
+
+    const txtEntry = manifest.entries.find((e) => e.photo_path.endsWith('.txt'));
+    expect(txtEntry).toBeUndefined();
+
+    // Clean up
+    const { rm: rmFile } = await import('node:fs/promises');
+    await rmFile(join(testRoot, 'catalog/transformers/mmc/r-03-bovis/notes.txt'));
+  });
+
+  it('throws when no images are found', async () => {
+    const emptyDir = join(testRoot, 'empty-root');
+    await mkdir(emptyDir, { recursive: true });
+
+    await expect(scanSourceDir(emptyDir)).rejects.toThrow('No images found');
+
+    await rm(emptyDir, { recursive: true, force: true });
+  });
+
+  it('handles missing tiers gracefully', async () => {
+    // A directory with only catalog/ (no training-only/) should still work
+    const partialRoot = join(testRoot, 'partial');
+    await mkdir(join(partialRoot, 'catalog/transformers/mmc/r-03-bovis'), { recursive: true });
+    await writeFile(join(partialRoot, 'catalog/transformers/mmc/r-03-bovis/img.webp'), 'data');
+
+    const manifest = await scanSourceDir(partialRoot);
+
+    expect(manifest.stats.total_photos).toBe(1);
+    expect(manifest.entries[0]!.label).toBe('transformers/r-03-bovis');
+
+    await rm(partialRoot, { recursive: true, force: true });
+  });
+});

--- a/ml/src/scan.ts
+++ b/ml/src/scan.ts
@@ -1,0 +1,109 @@
+import { readdir, stat } from 'node:fs/promises';
+import { join, extname } from 'node:path';
+import type { Manifest, ManifestEntry } from './types.js';
+
+const IMAGE_EXTENSIONS = new Set(['.webp', '.jpg', '.jpeg', '.png', '.heic']);
+const TIERS = ['catalog', 'training-only'] as const;
+const SKIP_DIRS = new Set(['_unmatched', '.DS_Store']);
+
+/**
+ * Scan a seed-images directory tree and produce a Manifest compatible with the
+ * existing prepare-data pipeline.
+ *
+ * Expected structure:
+ *   {sourceDir}/{tier}/{franchise}/{manufacturer}/{item}/{image-files}
+ *
+ * Tiers "catalog" and "training-only" are merged — images from both tiers for the
+ * same franchise/item produce entries in the same label group.
+ *
+ * Directories named "_unmatched" are skipped at any level.
+ *
+ * @param sourceDir - Root directory (e.g., /Volumes/WD 6TB/track-em-toys/test-images)
+ */
+export async function scanSourceDir(sourceDir: string): Promise<Manifest> {
+  const entries: ManifestEntry[] = [];
+  const franchises = new Set<string>();
+  const items = new Set<string>();
+
+  for (const tier of TIERS) {
+    const tierPath = join(sourceDir, tier);
+
+    let franchiseDirs: string[];
+    try {
+      franchiseDirs = await readdir(tierPath);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') continue;
+      throw err;
+    }
+
+    for (const franchise of franchiseDirs) {
+      if (SKIP_DIRS.has(franchise)) continue;
+      const franchisePath = join(tierPath, franchise);
+      if (!(await isDirectory(franchisePath))) continue;
+
+      const manufacturerDirs = await readdir(franchisePath);
+
+      for (const manufacturer of manufacturerDirs) {
+        if (SKIP_DIRS.has(manufacturer)) continue;
+        const manufacturerPath = join(franchisePath, manufacturer);
+        if (!(await isDirectory(manufacturerPath))) continue;
+
+        const itemDirs = await readdir(manufacturerPath);
+
+        for (const item of itemDirs) {
+          if (SKIP_DIRS.has(item)) continue;
+          const itemPath = join(manufacturerPath, item);
+          if (!(await isDirectory(itemPath))) continue;
+
+          const files = await readdir(itemPath);
+          const imageFiles = files.filter((f) => {
+            const ext = extname(f).toLowerCase();
+            return IMAGE_EXTENSIONS.has(ext);
+          });
+
+          for (const file of imageFiles) {
+            const label = `${franchise}/${item}`;
+            entries.push({
+              photo_path: join(itemPath, file),
+              label,
+              item_name: item,
+              franchise_slug: franchise,
+              item_slug: item,
+            });
+          }
+
+          if (imageFiles.length > 0) {
+            franchises.add(franchise);
+            items.add(`${franchise}/${item}`);
+          }
+        }
+      }
+    }
+  }
+
+  if (entries.length === 0) {
+    throw new Error(`No images found in source directory: ${sourceDir}`);
+  }
+
+  return {
+    version: 1,
+    exported_at: new Date().toISOString(),
+    stats: {
+      total_photos: entries.length,
+      items: items.size,
+      franchises: franchises.size,
+      low_photo_items: 0, // computed by balance analysis downstream
+    },
+    entries,
+    warnings: [],
+  };
+}
+
+async function isDirectory(path: string): Promise<boolean> {
+  try {
+    const s = await stat(path);
+    return s.isDirectory();
+  } catch {
+    return false;
+  }
+}

--- a/ml/src/types.ts
+++ b/ml/src/types.ts
@@ -32,8 +32,12 @@ export interface Manifest {
   warnings: ManifestWarning[];
 }
 
+export type CliSource =
+  | { mode: 'manifest'; manifestPath: string }
+  | { mode: 'source-dir'; sourceDir: string };
+
 export interface CliOptions {
-  manifestPath: string;
+  source: CliSource;
   outputDir: string;
   targetCount: number;
   format: 'webp' | 'jpeg';


### PR DESCRIPTION
## Summary

- Add `--source-dir` flag to `prepare-data` CLI as alternative to `--manifest`, scanning seed-images directory trees directly
- New `scan.ts` module walks `{tier}/{franchise}/{manufacturer}/{item}/` structure, merges `catalog/` and `training-only/` tiers, skips `_unmatched/`
- Updated docs: ml/README.md rewrite, ADR extension, roadmap Phase 4.0a marked DONE, test scenarios added

## Test plan

- [x] All 87 ML tests pass (7 test files), including 8 new scan tests
- [x] TypeScript compiles with zero errors
- [ ] Manual: run `npm run prepare-data -- --source-dir "/Volumes/WD 6TB/track-em-toys/test-images"` against real seed images
- [ ] Manual: verify `--manifest` mode still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)