### PR TITLE
test(web): add collection E2E tests (#104)

### DIFF
--- a/changelog/2026-03-23T204537Z_collection-e2e-tests.md
+++ b/changelog/2026-03-23T204537Z_collection-e2e-tests.md
@@ -1,0 +1,87 @@
+# Collection E2E Tests
+
+**Date:** 2026-03-23
+**Time:** 20:45:37 UTC
+**Type:** Feature
+**Phase:** 1.8
+**Version:** v1.8.2
+
+## Summary
+
+Added 12 Playwright E2E tests covering all collection management user flows (Issue #104). Introduced `MockCollectionState`, a stateful mock class that enables mutation chain testing (add, remove, undo restore). Also fixed 7 pre-existing E2E failures in catalog specs caused by missing `thumbnail_url` fields and collection endpoint mocks.
+
+---
+
+## Changes Implemented
+
+### 1. Collection E2E Test Suite
+
+12 tests across 6 describe blocks covering: empty state, dashboard stats, add from catalog (including multiple copies), collection page display, filtering (franchise/condition/search), edit/remove with undo, view toggle persistence, and navigation.
+
+**Created:**
+
+- `web/e2e/collection.spec.ts` — 12 E2E tests for collection management flows
+- `web/e2e/fixtures/mock-helpers.ts` — `MockCollectionState` class, `makeCollectionItem()` factory, `mockEmptyCollection()` shared helper, `setupCatalogForAddFlow()` catalog mock helper
+- `docs/test-scenarios/E2E_COLLECTION_MANAGEMENT.md` — Gherkin scenario document (11 scenarios)
+
+### 2. Pre-Existing E2E Fixes
+
+Added `thumbnail_url: null` to mock item data and collection endpoint mocks (`mockEmptyCollection`) to 3 catalog spec files that were broken by PR #108's schema changes.
+
+**Modified:**
+
+- `web/e2e/catalog-browse.spec.ts` — added `thumbnail_url` to mock items + `mockEmptyCollection()`
+- `web/e2e/catalog-detail-pages.spec.ts` — added `thumbnail_url` to mock items + `mockEmptyCollection()`
+- `web/e2e/catalog-search.spec.ts` — added `thumbnail_url` to mock search results + `mockEmptyCollection()`
+- `web/playwright.config.ts` — added `collection.spec.ts` to user project testMatch
+- `docs/test-scenarios/README.md` — updated mapping table status
+
+---
+
+## Technical Details
+
+### MockCollectionState
+
+A stateful class where `page.route()` handlers close over the instance. Mutations (`addItem`, `removeItem`, `restoreItem`, `patchItem`) modify internal state, and subsequent GET requests automatically return updated data without re-registering routes. This enables testing:
+
+- Add item twice → check count increments from 1 to 2
+- Remove item → undo via toast → item restored in collection
+
+### Route Registration Order
+
+Playwright matches last-registered-first. The `register()` method registers:
+1. Catch-all `**/collection/**` (lowest priority)
+2. `**/collection` (list GET + add POST)
+3. `**/collection/stats`
+4. `**/collection/check**`
+5. `/collection/:uuid/restore` (regex)
+6. `/collection/:uuid` (regex — PATCH/DELETE)
+
+---
+
+## Validation & Testing
+
+- 12 collection E2E tests pass
+- 58 total E2E tests pass (1 pre-existing skip)
+- All API and Web checks pass (tests, lint, typecheck, format, build)
+
+---
+
+## Related Files
+
+| Action | File |
+|--------|------|
+| Created | `web/e2e/collection.spec.ts` |
+| Created | `web/e2e/fixtures/mock-helpers.ts` |
+| Created | `docs/test-scenarios/E2E_COLLECTION_MANAGEMENT.md` |
+| Modified | `web/e2e/catalog-browse.spec.ts` |
+| Modified | `web/e2e/catalog-detail-pages.spec.ts` |
+| Modified | `web/e2e/catalog-search.spec.ts` |
+| Modified | `web/playwright.config.ts` |
+| Modified | `docs/test-scenarios/README.md` |
+
+---
+
+## Status
+
+✅ COMPLETE

--- a/docs/test-scenarios/E2E_COLLECTION_MANAGEMENT.md
+++ b/docs/test-scenarios/E2E_COLLECTION_MANAGEMENT.md
@@ -1,0 +1,169 @@
+# E2E: Collection Management
+
+## Background
+
+Given the web app is running
+And a user with role "user" exists
+And the user is signed in
+
+## Scenarios
+
+### Empty State
+
+#### Display: Empty collection page shows CTA
+
+```gherkin
+Scenario: User with no collection items sees empty state
+  Given the user has no items in their collection
+  When they navigate to /collection
+  Then a heading "My Collection" is displayed
+  And the text "Your collection is empty" is shown
+  And a "Browse Catalog" button links to /catalog
+```
+
+#### Display: Dashboard shows empty collection CTA
+
+```gherkin
+Scenario: Dashboard displays empty collection state
+  Given the user has no items in their collection
+  When they navigate to /
+  Then the text "Start building your collection" is shown
+  And a "Browse Catalog" button links to /catalog
+```
+
+### Dashboard Stats
+
+#### Happy Path: Dashboard shows collection stats cards
+
+```gherkin
+Scenario: Dashboard displays populated collection stats
+  Given the user has 5 copies of 4 unique items across 2 franchises
+  And 2 items are in mint_sealed condition
+  When they navigate to /
+  Then a "Your Collection" heading is shown
+  And a stats card shows "5" copies
+  And a stats card shows "4" unique items
+  And a stats card shows "2" franchises
+  And a stats card shows "2" mint sealed
+  And a "View All" button links to /collection
+```
+
+### Add to Collection
+
+#### Happy Path: Add item from catalog detail page
+
+```gherkin
+Scenario: User adds an item to their collection from the catalog
+  Given the user is on a catalog item detail page
+  And the item is not in their collection
+  And an "Add to Collection" button is visible
+  When they click "Add to Collection"
+  Then an "Add to Collection" dialog opens
+  And the condition defaults to "Unknown"
+  When they click a condition option (e.g., "Loose Complete")
+  And click the "Add to Collection" submit button
+  Then a success toast shows "<item name> added to your collection"
+  And the button changes to show "In collection (1)" with "Add Copy" label
+```
+
+#### Happy Path: Add multiple copies of the same item
+
+```gherkin
+Scenario: User adds a second copy of an item already in their collection
+  Given the user has one copy of an item in their collection
+  And the item detail page shows "In collection (1)" and "Add Copy"
+  When they click "Add Copy"
+  And complete the add dialog
+  Then a success toast confirms the addition
+  And the button updates to show "In collection (2)"
+```
+
+### Collection Page Display
+
+#### Happy Path: Collection page shows stats bar and items
+
+```gherkin
+Scenario: User views their populated collection
+  Given the user has items in their collection
+  When they navigate to /collection
+  Then the stats bar shows total copies and unique items
+  And franchise pill buttons are displayed
+  And collection item cards are visible in the grid
+  And each card shows the item name and condition badge
+```
+
+### Filtering
+
+#### Happy Path: Filter by franchise and condition
+
+```gherkin
+Scenario: User filters collection by franchise pill and condition dropdown
+  Given the user is on /collection with items from multiple franchises
+  When they click a franchise pill (e.g., "Transformers")
+  Then the URL updates to include franchise=transformers
+  When they select a condition from the "Filter by condition" dropdown
+  Then the URL updates to include the condition parameter
+```
+
+#### Happy Path: Debounced search filters collection
+
+```gherkin
+Scenario: User searches their collection by text
+  Given the user is on /collection
+  When they type "bulkhead" in the search input
+  And wait for the 300ms debounce
+  Then the URL updates to include search=bulkhead
+```
+
+### Edit and Remove
+
+#### Happy Path: Edit collection item condition and notes
+
+```gherkin
+Scenario: User edits a collection item's condition
+  Given the user is on /collection with at least one item
+  When they click the edit button (pencil icon) on an item card
+  Then the "Edit Collection Entry" dialog opens
+  And the current condition is pre-selected
+  When they select a different condition (e.g., "Opened Complete")
+  And click "Save Changes"
+  Then a success toast shows "Collection entry updated"
+  And the dialog closes
+```
+
+#### Happy Path: Remove item with undo restore
+
+```gherkin
+Scenario: User removes an item and restores it via undo
+  Given the user is on /collection with at least one item
+  When they click the edit button on an item card
+  And click the "Remove" button in the dialog
+  Then the dialog closes
+  And a toast shows "Removed from collection" with the item name
+  And the toast has an "Undo" action button
+  When they click the "Undo" button in the toast
+  Then a success toast shows "Restored to collection"
+```
+
+### View Toggle
+
+#### Happy Path: Switch between grid and table views
+
+```gherkin
+Scenario: User toggles between grid and table view
+  Given the user is on /collection in the default grid view
+  When they click the "Table view" radio button
+  Then the collection displays as a table with column headers
+  When they navigate away and return to /collection
+  Then the table view persists (localStorage preference)
+```
+
+### Navigation
+
+#### Display: MainNav active state on collection page
+
+```gherkin
+Scenario: My Collection nav link is active on /collection
+  Given the user is on /collection
+  Then the "My Collection" navigation link has aria-current="page"
+```

--- a/docs/test-scenarios/README.md
+++ b/docs/test-scenarios/README.md
@@ -39,7 +39,7 @@ See [TESTING_SCENARIOS.md](../guides/TESTING_SCENARIOS.md) for the scenario-driv
 | E2E_GDPR_DELETION.md                                         | 1.12 Account Deletion                                               | Not started                 |
 | [UNIT_ML_TRAINING_DATA.md](UNIT_ML_TRAINING_DATA.md)         | `ml/src/*.test.ts`                                                  | ✅ Implemented |
 | [INT_COLLECTION_API.md](INT_COLLECTION_API.md)               | `api/src/collection/routes.test.ts`                                 | ✅ Implemented |
-| E2E_COLLECTION_MANAGEMENT.md                                 | 1.8 Web Collection UI                                               | Not started |
+| [E2E_COLLECTION_MANAGEMENT.md](E2E_COLLECTION_MANAGEMENT.md) | `web/e2e/collection.spec.ts`                                        | ✅ Implemented |
 
 ## Creating a New Scenario
 

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -128,6 +128,10 @@ cd web && npm run format:check # Prettier check (CI mode)
 - Prefer `getByRole('cell', { name: /.../ })` over `getByText()` for table data — text appears in both cell content and row accessible names, causing ambiguity
 - When a page has multiple Radix `Select` components (e.g., filter + per-row role selector), `getByRole('combobox')` fails Playwright strict mode — disambiguate with `getByRole('combobox', { name: /aria-label pattern/ })`
 - `vite.config.ts` `preview` section does NOT inherit from `server` — host, port, and https must be set explicitly in both. Without this, preview defaults to `localhost` while dev uses the custom hostname, causing SameSite cookie mismatches in E2E tests.
+- `mockEmptyCollection(page)` in `e2e/fixtures/mock-helpers.ts` — shared helper that mocks empty collection endpoints (check, stats, list). Required in any E2E spec that renders item detail components (they call `useCollectionCheck`).
+- `MockCollectionState` in `e2e/fixtures/mock-helpers.ts` — stateful mock for collection E2E tests. Route handlers close over the instance, so mutations (`addItem`, `removeItem`) are reflected in subsequent GET responses without re-registering routes.
+- When adding a field to a Zod schema (e.g., `CatalogItemSchema`), also update mock data in E2E spec files — E2E mocks go through Zod parse in the browser and will fail if required fields are missing.
+- `ConditionSelector` renders `<button>` elements (not Radix `Select`) — E2E tests click `getByRole('button', { name: /Opened Complete/ })`. The filter condition on the collection page uses a Radix `Select` combobox (`getByRole('combobox', { name: /Filter by condition/ })`).
 
 ### Image Loading
 

--- a/web/e2e/catalog-browse.spec.ts
+++ b/web/e2e/catalog-browse.spec.ts
@@ -6,6 +6,7 @@
  */
 
 import { test, expect } from './fixtures/e2e-fixtures';
+import { mockEmptyCollection } from './fixtures/mock-helpers';
 
 // --- Fixtures ---
 
@@ -68,6 +69,7 @@ const mockItems = {
       characters: [{ slug: 'bulkhead', name: 'Bulkhead', appearance_slug: 'animated', is_primary: true }],
       manufacturer: { slug: 'hasbro', name: 'Hasbro' },
       toy_line: { slug: 'legacy', name: 'Legacy' },
+      thumbnail_url: null,
       size_class: 'Voyager',
       year_released: 2023,
       is_third_party: false,
@@ -81,6 +83,7 @@ const mockItems = {
       characters: [{ slug: 'optimus-prime', name: 'Optimus Prime', appearance_slug: 'g1-cartoon', is_primary: true }],
       manufacturer: { slug: 'takara-tomy', name: 'Takara Tomy' },
       toy_line: { slug: 'masterpiece', name: 'Masterpiece' },
+      thumbnail_url: null,
       size_class: 'Leader',
       year_released: 2019,
       is_third_party: false,
@@ -117,6 +120,8 @@ const mockItemDetail = {
 // --- Helpers ---
 
 async function setupCatalogMocks(page: import('@playwright/test').Page) {
+  await mockEmptyCollection(page);
+
   // Catch-all for unhandled catalog requests — prevents hitting the real API
   await page.route('**/catalog/**', (route) => {
     if (route.request().resourceType() === 'document') return route.continue();

--- a/web/e2e/catalog-detail-pages.spec.ts
+++ b/web/e2e/catalog-detail-pages.spec.ts
@@ -5,6 +5,7 @@
  */
 
 import { test, expect } from './fixtures/e2e-fixtures';
+import { mockEmptyCollection } from './fixtures/mock-helpers';
 
 // --- Fixtures ---
 
@@ -63,6 +64,7 @@ const mockItemDetail = {
   ],
   manufacturer: { slug: 'hasbro', name: 'Hasbro' },
   toy_line: { slug: 'legacy', name: 'Legacy' },
+  thumbnail_url: null,
   size_class: 'Voyager',
   year_released: 2023,
   is_third_party: false,
@@ -101,6 +103,7 @@ const mockRelatedItems = {
       characters: [{ slug: 'optimus-prime', name: 'Optimus Prime', appearance_slug: 'g1-cartoon', is_primary: true }],
       manufacturer: { slug: 'takara-tomy', name: 'Takara Tomy' },
       toy_line: { slug: 'masterpiece', name: 'Masterpiece' },
+      thumbnail_url: null,
       size_class: 'Leader',
       year_released: 2019,
       is_third_party: false,
@@ -178,6 +181,8 @@ async function setupDetailMocks(page: import('@playwright/test').Page) {
     if (route.request().resourceType() === 'document') return route.continue();
     return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ relationships: [] }) });
   });
+
+  await mockEmptyCollection(page);
 
   // Catch-all for other items requests (facets, list without character filter)
   await page.route('**/catalog/franchises/transformers/items**', (route) => {

--- a/web/e2e/catalog-search.spec.ts
+++ b/web/e2e/catalog-search.spec.ts
@@ -5,6 +5,7 @@
  */
 
 import { test, expect } from './fixtures/e2e-fixtures';
+import { mockEmptyCollection } from './fixtures/mock-helpers';
 
 // --- Fixtures ---
 
@@ -20,6 +21,7 @@ const mockSearchResults = {
       character: null,
       manufacturer: null,
       toy_line: null,
+      thumbnail_url: null,
       size_class: null,
       year_released: null,
       is_third_party: null,
@@ -35,6 +37,7 @@ const mockSearchResults = {
       character: { slug: 'optimus-prime', name: 'Optimus Prime' },
       manufacturer: { slug: 'takara-tomy', name: 'Takara Tomy' },
       toy_line: { slug: 'masterpiece', name: 'Masterpiece' },
+      thumbnail_url: null,
       size_class: 'Leader',
       year_released: 2019,
       is_third_party: false,
@@ -71,6 +74,7 @@ const mockItemDetail = {
   ],
   manufacturer: { slug: 'takara-tomy', name: 'Takara Tomy' },
   toy_line: { slug: 'masterpiece', name: 'Masterpiece' },
+  thumbnail_url: null,
   size_class: 'Leader',
   year_released: 2019,
   is_third_party: false,
@@ -88,6 +92,8 @@ const mockItemDetail = {
 // --- Helpers ---
 
 async function setupSearchMocks(page: import('@playwright/test').Page) {
+  await mockEmptyCollection(page);
+
   // Catch-all for unhandled catalog requests — prevents hitting the real API
   await page.route('**/catalog/**', (route) => {
     if (route.request().resourceType() === 'document') return route.continue();

--- a/web/e2e/collection.spec.ts
+++ b/web/e2e/collection.spec.ts
@@ -1,0 +1,281 @@
+/**
+ * E2E: Collection Management
+ *
+ * Scenarios from docs/test-scenarios/E2E_COLLECTION_MANAGEMENT.md
+ *
+ * Auth is handled by e2e-fixtures (user project). Collection API data
+ * is mocked via MockCollectionState, which provides stateful responses
+ * so mutation chains (add, remove, restore) reflect in subsequent GETs.
+ */
+
+import { test, expect } from './fixtures/e2e-fixtures';
+import { MockCollectionState, makeCollectionItem, setupCatalogForAddFlow } from './fixtures/mock-helpers';
+
+// ─── Empty State ──────────────────────────────────────────────────────────────
+
+test.describe('Collection empty state', () => {
+  test('Given empty collection, When navigating to /collection, Then empty state CTA is displayed', async ({
+    page,
+  }) => {
+    const state = new MockCollectionState([]);
+    await state.register(page);
+    await page.goto('/collection');
+
+    await expect(page.getByRole('heading', { name: 'My Collection' })).toBeVisible();
+    await expect(page.getByText('Your collection is empty')).toBeVisible();
+    await expect(page.getByRole('link', { name: /Browse Catalog/ })).toHaveAttribute('href', '/catalog');
+  });
+
+  test('Given empty collection, When navigating to /, Then dashboard shows empty collection CTA', async ({ page }) => {
+    const state = new MockCollectionState([]);
+    await state.register(page);
+    await page.goto('/');
+
+    await expect(page.getByText(/Start building your collection/)).toBeVisible();
+    await expect(page.getByRole('link', { name: /Browse Catalog/ })).toBeVisible();
+  });
+});
+
+// ─── Dashboard Stats ──────────────────────────────────────────────────────────
+
+test.describe('Dashboard populated stats', () => {
+  test('Given populated collection, When navigating to /, Then stats cards are shown', async ({ page }) => {
+    const state = new MockCollectionState([
+      makeCollectionItem({ condition: 'mint_sealed' }),
+      makeCollectionItem({ condition: 'mint_sealed' }),
+      makeCollectionItem({ condition: 'loose_complete' }),
+      makeCollectionItem({
+        item_id: 'a0000000-0000-4000-a000-000000000002',
+        item_name: 'MP-44 Optimus Prime',
+        item_slug: 'mp-44-optimus-prime',
+        condition: 'loose_complete',
+      }),
+      makeCollectionItem({
+        item_id: 'a0000000-0000-4000-a000-000000000003',
+        item_name: 'Classified Snake Eyes',
+        item_slug: 'classified-snake-eyes',
+        franchise: { slug: 'gi-joe', name: 'G.I. Joe' },
+        condition: 'loose_complete',
+      }),
+    ]);
+    await state.register(page);
+    await page.goto('/');
+
+    await expect(page.getByRole('heading', { name: 'Your Collection' })).toBeVisible();
+
+    const grid = page.locator('.grid');
+    await expect(grid.locator('div').filter({ hasText: /^5Copies$/ })).toBeVisible();
+    await expect(grid.locator('div').filter({ hasText: /^3Unique Items$/ })).toBeVisible();
+    await expect(grid.locator('div').filter({ hasText: /^2Franchises$/ })).toBeVisible();
+    await expect(grid.locator('div').filter({ hasText: /^2Mint Sealed$/ })).toBeVisible();
+
+    await expect(page.getByRole('link', { name: /View All/ })).toBeVisible();
+  });
+});
+
+// ─── Add to Collection (from Catalog) ─────────────────────────────────────────
+
+test.describe('Add to collection from catalog', () => {
+  test('Given catalog item detail, When adding to collection, Then success toast and badge appear', async ({
+    page,
+  }) => {
+    const state = new MockCollectionState([]);
+    await state.register(page);
+    await setupCatalogForAddFlow(page);
+
+    await page.goto('/catalog/transformers/items/legacy-bulkhead');
+    await expect(page.getByRole('heading', { name: 'Legacy Bulkhead' })).toBeVisible({ timeout: 10_000 });
+
+    const addButton = page.getByRole('button', { name: 'Add to Collection' });
+    await expect(addButton).toBeVisible();
+    await addButton.click();
+
+    await expect(page.getByRole('heading', { name: 'Add to Collection' })).toBeVisible();
+    await page.getByRole('button', { name: /Loose Complete/ }).click();
+    await page.getByRole('button', { name: 'Add to Collection' }).last().click();
+
+    const toast = page.locator('[data-sonner-toast]').filter({ hasText: /Legacy Bulkhead added to your collection/ });
+    await expect(toast).toBeVisible({ timeout: 5_000 });
+
+    await expect(page.getByText('In collection (1)')).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByRole('button', { name: 'Add Copy' })).toBeVisible();
+  });
+
+  test('Given item already in collection, When adding a second copy, Then count increments to 2', async ({ page }) => {
+    // Start with one copy already in collection
+    const state = new MockCollectionState([
+      makeCollectionItem({
+        item_id: 'a0000000-0000-4000-a000-000000000001',
+        condition: 'loose_complete',
+      }),
+    ]);
+    await state.register(page);
+    await setupCatalogForAddFlow(page);
+
+    await page.goto('/catalog/transformers/items/legacy-bulkhead');
+    await expect(page.getByRole('heading', { name: 'Legacy Bulkhead' })).toBeVisible({ timeout: 10_000 });
+
+    await expect(page.getByText('In collection (1)')).toBeVisible({ timeout: 5_000 });
+    const addCopyButton = page.getByRole('button', { name: 'Add Copy' });
+    await expect(addCopyButton).toBeVisible();
+    await addCopyButton.click();
+
+    await expect(page.getByRole('heading', { name: 'Add Another Copy' })).toBeVisible();
+    await page.getByRole('button', { name: 'Add to Collection' }).click();
+
+    const toast = page.locator('[data-sonner-toast]').filter({ hasText: /Legacy Bulkhead added to your collection/ });
+    await expect(toast).toBeVisible({ timeout: 5_000 });
+
+    await expect(page.getByText('In collection (2)')).toBeVisible({ timeout: 5_000 });
+  });
+});
+
+// ─── Collection Page Display and Filtering ────────────────────────────────────
+
+test.describe('Collection page display and filtering', () => {
+  test('Given populated collection, When navigating to /collection, Then stats bar and items are visible', async ({
+    page,
+  }) => {
+    const state = new MockCollectionState([
+      makeCollectionItem({ condition: 'loose_complete' }),
+      makeCollectionItem({
+        item_id: 'a0000000-0000-4000-a000-000000000002',
+        item_name: 'Classified Snake Eyes',
+        item_slug: 'classified-snake-eyes',
+        franchise: { slug: 'gi-joe', name: 'G.I. Joe' },
+        condition: 'mint_sealed',
+      }),
+    ]);
+    await state.register(page);
+    await page.goto('/collection');
+
+    await expect(page.getByText('2 items')).toBeVisible({ timeout: 10_000 });
+
+    // Franchise pills
+    await expect(page.getByRole('button', { name: 'All' })).toBeVisible();
+    await expect(page.getByRole('button', { name: /Transformers/ })).toBeVisible();
+    await expect(page.getByRole('button', { name: /G\.I\. Joe/ })).toBeVisible();
+
+    // Item cards with condition badges
+    await expect(page.getByText('Legacy Bulkhead')).toBeVisible();
+    await expect(page.getByText('Classified Snake Eyes')).toBeVisible();
+    await expect(page.getByText('LC')).toBeVisible();
+    await expect(page.getByText('MISB')).toBeVisible();
+  });
+
+  test('Given collection page, When clicking franchise pill and condition filter, Then URL updates', async ({
+    page,
+  }) => {
+    const state = new MockCollectionState([
+      makeCollectionItem({ condition: 'loose_complete' }),
+      makeCollectionItem({
+        item_id: 'a0000000-0000-4000-a000-000000000002',
+        item_name: 'Classified Snake Eyes',
+        item_slug: 'classified-snake-eyes',
+        franchise: { slug: 'gi-joe', name: 'G.I. Joe' },
+        condition: 'mint_sealed',
+      }),
+    ]);
+    await state.register(page);
+    await page.goto('/collection');
+    await expect(page.getByText('2 items')).toBeVisible({ timeout: 10_000 });
+
+    await page.getByRole('button', { name: /Transformers/ }).click();
+    await expect(page).toHaveURL(/franchise=transformers/);
+
+    await page.getByRole('combobox', { name: /Filter by condition/ }).click();
+    await page.getByRole('option', { name: 'Loose Complete' }).click();
+    await expect(page).toHaveURL(/condition=loose_complete/);
+  });
+
+  test('Given collection page, When typing in search, Then URL updates after debounce', async ({ page }) => {
+    const state = new MockCollectionState([makeCollectionItem()]);
+    await state.register(page);
+    await page.goto('/collection');
+    await expect(page.getByText('1 item')).toBeVisible({ timeout: 10_000 });
+
+    await page.getByRole('textbox', { name: /Search collection/ }).fill('bulkhead');
+
+    // Wait for debounce (300ms) + URL navigation
+    await expect(page).toHaveURL(/search=bulkhead/, { timeout: 2_000 });
+  });
+});
+
+// ─── Edit and Remove ──────────────────────────────────────────────────────────
+
+test.describe('Edit and remove collection items', () => {
+  test('Given collection item, When editing condition, Then success toast appears', async ({ page }) => {
+    const state = new MockCollectionState([makeCollectionItem({ condition: 'unknown' })]);
+    await state.register(page);
+    await page.goto('/collection');
+    await expect(page.getByText('Legacy Bulkhead')).toBeVisible({ timeout: 10_000 });
+
+    await page.getByRole('button', { name: /Edit Legacy Bulkhead/ }).click();
+    await expect(page.getByRole('heading', { name: 'Edit Collection Entry' })).toBeVisible();
+
+    await page.getByRole('button', { name: /Opened Complete/ }).click();
+    await page.getByRole('button', { name: 'Save Changes' }).click();
+
+    const toast = page.locator('[data-sonner-toast]').filter({ hasText: /Collection entry updated/ });
+    await expect(toast).toBeVisible({ timeout: 5_000 });
+  });
+
+  test('Given collection item, When removing and clicking Undo, Then item is restored', async ({ page }) => {
+    const state = new MockCollectionState([makeCollectionItem()]);
+    await state.register(page);
+    await page.goto('/collection');
+    await expect(page.getByText('Legacy Bulkhead')).toBeVisible({ timeout: 10_000 });
+
+    await page.getByRole('button', { name: /Edit Legacy Bulkhead/ }).click();
+    await expect(page.getByRole('heading', { name: 'Edit Collection Entry' })).toBeVisible();
+    await page.getByRole('button', { name: 'Remove' }).click();
+
+    const removeToast = page.locator('[data-sonner-toast]').filter({ hasText: /Removed from collection/ });
+    await expect(removeToast).toBeVisible({ timeout: 5_000 });
+    await expect(removeToast).toContainText('Legacy Bulkhead');
+
+    await removeToast.getByRole('button', { name: 'Undo' }).click();
+
+    const restoreToast = page.locator('[data-sonner-toast]').filter({ hasText: /Restored to collection/ });
+    await expect(restoreToast).toBeVisible({ timeout: 5_000 });
+  });
+});
+
+// ─── View Toggle ──────────────────────────────────────────────────────────────
+
+test.describe('View toggle', () => {
+  test('Given grid view, When switching to table view, Then table is shown and persists', async ({ page }) => {
+    const state = new MockCollectionState([makeCollectionItem()]);
+    await state.register(page);
+    await page.goto('/collection');
+    await expect(page.getByText('Legacy Bulkhead')).toBeVisible({ timeout: 10_000 });
+
+    await expect(page.getByRole('radio', { name: 'Card view' })).toHaveAttribute('aria-checked', 'true');
+
+    await page.getByRole('radio', { name: 'Table view' }).click();
+    await expect(page.getByRole('columnheader', { name: 'Item' })).toBeVisible();
+    await expect(page.getByRole('columnheader', { name: 'Condition' })).toBeVisible();
+
+    const viewMode = await page.evaluate(() => localStorage.getItem('trackem:collection-view'));
+    expect(viewMode).toBe('"table"');
+
+    // Navigate away and back — table view persists
+    await page.goto('/');
+    await page.goto('/collection');
+    await expect(page.getByRole('columnheader', { name: 'Item' })).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByRole('radio', { name: 'Table view' })).toHaveAttribute('aria-checked', 'true');
+  });
+});
+
+// ─── Navigation ───────────────────────────────────────────────────────────────
+
+test.describe('Collection navigation', () => {
+  test('Given user on /collection, Then My Collection nav link has aria-current="page"', async ({ page }) => {
+    const state = new MockCollectionState([makeCollectionItem()]);
+    await state.register(page);
+    await page.goto('/collection');
+
+    const collectionLink = page.getByRole('link', { name: 'My Collection' });
+    await expect(collectionLink).toHaveAttribute('aria-current', 'page');
+  });
+});

--- a/web/e2e/fixtures/mock-helpers.ts
+++ b/web/e2e/fixtures/mock-helpers.ts
@@ -1,0 +1,362 @@
+/**
+ * Shared mock helpers for E2E tests.
+ *
+ * Provides:
+ * - MockCollectionState: stateful mock for collection API endpoints
+ * - mockEmptyCollection(): empty collection mocks for catalog tests
+ * - makeCollectionItem(): factory for CollectionItem-shaped objects
+ * - setupCatalogForAddFlow(): catalog route mocks for the "add from catalog" flow
+ */
+
+import type { Page, Route } from '@playwright/test';
+
+// ─── Primitive helpers ────────────────────────────────────────────────────────
+
+function isDocRequest(route: Route): boolean {
+  return route.request().resourceType() === 'document';
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return { status, contentType: 'application/json', body: JSON.stringify(body) };
+}
+
+export interface MockCollectionItem {
+  id: string;
+  item_id: string;
+  item_name: string;
+  item_slug: string;
+  franchise: { slug: string; name: string };
+  manufacturer: { slug: string; name: string } | null;
+  toy_line: { slug: string; name: string };
+  thumbnail_url: string | null;
+  condition: string;
+  notes: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export function makeCollectionItem(overrides?: Partial<MockCollectionItem>): MockCollectionItem {
+  return {
+    id: crypto.randomUUID(),
+    item_id: 'a0000000-0000-4000-a000-000000000001',
+    item_name: 'Legacy Bulkhead',
+    item_slug: 'legacy-bulkhead',
+    franchise: { slug: 'transformers', name: 'Transformers' },
+    manufacturer: { slug: 'hasbro', name: 'Hasbro' },
+    toy_line: { slug: 'legacy', name: 'Legacy' },
+    thumbnail_url: null,
+    condition: 'loose_complete',
+    notes: null,
+    created_at: '2026-01-15T10:00:00.000Z',
+    updated_at: '2026-01-15T10:00:00.000Z',
+    ...overrides,
+  };
+}
+
+// ─── Empty collection mock (for catalog/search specs) ────────────────────────
+
+/**
+ * Install empty-collection route mocks so catalog pages don't hit the real API
+ * for collection endpoints (useCollectionCheck, stats, list).
+ *
+ * Registration order: catch-all first (lowest priority), then specifics.
+ */
+export async function mockEmptyCollection(page: Page): Promise<void> {
+  await page.route('**/collection/**', (route) => {
+    if (isDocRequest(route)) return route.continue();
+    return route.fulfill(jsonResponse({ items: {} }));
+  });
+  await page.route('**/collection', (route) => {
+    if (isDocRequest(route)) return route.continue();
+    return route.fulfill(jsonResponse({ data: [], next_cursor: null, total_count: 0 }));
+  });
+  await page.route('**/collection/stats', (route) => {
+    if (isDocRequest(route)) return route.continue();
+    return route.fulfill(jsonResponse({ total_copies: 0, unique_items: 0, by_franchise: [], by_condition: [] }));
+  });
+}
+
+// ─── MockCollectionState ──────────────────────────────────────────────────────
+
+/**
+ * Stateful mock for collection API endpoints.
+ *
+ * Route handlers read from this object at request time (via closures),
+ * so mutations like addItem() are reflected in subsequent GET responses
+ * without re-registering routes.
+ */
+export class MockCollectionState {
+  private _items: MockCollectionItem[];
+  private _deleted = new Set<string>();
+
+  constructor(initialItems: MockCollectionItem[] = []) {
+    this._items = [...initialItems];
+  }
+
+  get liveItems(): MockCollectionItem[] {
+    return this._items.filter((i) => !this._deleted.has(i.id));
+  }
+
+  get stats() {
+    const live = this.liveItems;
+    const franchiseMap = new Map<string, { slug: string; name: string; count: number }>();
+    const conditionMap = new Map<string, number>();
+
+    for (const item of live) {
+      const fKey = item.franchise.slug;
+      const existing = franchiseMap.get(fKey);
+      if (existing) {
+        existing.count++;
+      } else {
+        franchiseMap.set(fKey, { slug: fKey, name: item.franchise.name, count: 1 });
+      }
+      conditionMap.set(item.condition, (conditionMap.get(item.condition) ?? 0) + 1);
+    }
+
+    const uniqueItemIds = new Set(live.map((i) => i.item_id));
+
+    return {
+      total_copies: live.length,
+      unique_items: uniqueItemIds.size,
+      by_franchise: Array.from(franchiseMap.values()),
+      by_condition: Array.from(conditionMap.entries()).map(([condition, count]) => ({ condition, count })),
+    };
+  }
+
+  addItem(partial: { item_id: string; condition?: string; notes?: string }): MockCollectionItem {
+    const existing = this._items.find((i) => i.item_id === partial.item_id);
+    const newItem = makeCollectionItem({
+      item_id: partial.item_id,
+      item_name: existing?.item_name ?? 'Unknown Item',
+      item_slug: existing?.item_slug ?? 'unknown-item',
+      franchise: existing?.franchise ?? { slug: 'unknown', name: 'Unknown' },
+      manufacturer: existing?.manufacturer ?? null,
+      toy_line: existing?.toy_line ?? { slug: 'unknown', name: 'Unknown' },
+      condition: partial.condition ?? 'unknown',
+      notes: partial.notes?.trim() || null,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    });
+    this._items.push(newItem);
+    return newItem;
+  }
+
+  removeItem(id: string): void {
+    this._deleted.add(id);
+  }
+
+  restoreItem(id: string): MockCollectionItem | null {
+    this._deleted.delete(id);
+    return this._items.find((i) => i.id === id) ?? null;
+  }
+
+  patchItem(id: string, updates: { condition?: string; notes?: string | null }): MockCollectionItem | null {
+    const item = this._items.find((i) => i.id === id);
+    if (!item) return null;
+    if (updates.condition !== undefined) item.condition = updates.condition;
+    if (updates.notes !== undefined) item.notes = updates.notes;
+    item.updated_at = new Date().toISOString();
+    return item;
+  }
+
+  /**
+   * Install all collection API route handlers on the page.
+   * Call this BEFORE page.goto().
+   *
+   * Registration order matters: Playwright matches last-registered first.
+   * Catch-all is registered first (lowest priority), specifics later (highest priority).
+   */
+  async register(page: Page): Promise<void> {
+    // 1. Catch-all for /collection/** — lowest priority fallback
+    await page.route('**/collection/**', (route) => {
+      if (isDocRequest(route)) return route.continue();
+      return route.fulfill(jsonResponse({ data: [], next_cursor: null, total_count: 0 }));
+    });
+
+    // 2. GET /collection (list) + POST /collection (add)
+    await page.route('**/collection', (route) => {
+      if (isDocRequest(route)) return route.continue();
+      const method = route.request().method();
+
+      if (method === 'GET') {
+        return route.fulfill(
+          jsonResponse({
+            data: this.liveItems,
+            next_cursor: null,
+            total_count: this.liveItems.length,
+          })
+        );
+      }
+
+      if (method === 'POST') {
+        const body = route.request().postDataJSON() as { item_id: string; condition?: string; notes?: string };
+        const newItem = this.addItem(body);
+        return route.fulfill(jsonResponse(newItem, 201));
+      }
+
+      return route.fallback();
+    });
+
+    // 3. GET /collection/stats
+    await page.route('**/collection/stats', (route) => {
+      if (isDocRequest(route)) return route.continue();
+      return route.fulfill(jsonResponse(this.stats));
+    });
+
+    // 4. GET /collection/check?itemIds=...
+    await page.route('**/collection/check**', (route) => {
+      if (isDocRequest(route)) return route.continue();
+      const url = new URL(route.request().url());
+      const itemIds = url.searchParams.get('itemIds')?.split(',').filter(Boolean) ?? [];
+
+      const items: Record<string, { count: number; collection_ids: string[] }> = {};
+      for (const itemId of itemIds) {
+        const matching = this.liveItems.filter((i) => i.item_id === itemId);
+        items[itemId] = {
+          count: matching.length,
+          collection_ids: matching.map((i) => i.id),
+        };
+      }
+
+      return route.fulfill(jsonResponse({ items }));
+    });
+
+    // 5. POST /collection/:id/restore — must be registered before the generic :id route
+    await page.route(/\/collection\/[0-9a-f-]{36}\/restore$/, (route) => {
+      if (isDocRequest(route)) return route.continue();
+      if (route.request().method() !== 'POST') return route.fallback();
+
+      const urlPath = new URL(route.request().url()).pathname;
+      const id = urlPath.split('/').at(-2)!;
+      const restored = this.restoreItem(id);
+      if (restored) {
+        return route.fulfill(jsonResponse(restored));
+      }
+      return route.fulfill(jsonResponse({ error: 'Not found' }, 404));
+    });
+
+    // 6. PATCH /collection/:id + DELETE /collection/:id
+    await page.route(/\/collection\/[0-9a-f-]{36}$/, (route) => {
+      if (isDocRequest(route)) return route.continue();
+      const method = route.request().method();
+      const urlPath = new URL(route.request().url()).pathname;
+      const id = urlPath.split('/').pop()!;
+
+      if (method === 'PATCH') {
+        const body = route.request().postDataJSON() as { condition?: string; notes?: string | null };
+        const patched = this.patchItem(id, body);
+        if (patched) return route.fulfill(jsonResponse(patched));
+        return route.fulfill(jsonResponse({ error: 'Not found' }, 404));
+      }
+
+      if (method === 'DELETE') {
+        this.removeItem(id);
+        return route.fulfill({ status: 204, body: '' });
+      }
+
+      return route.fallback();
+    });
+  }
+}
+
+// ─── Catalog mocks for "add from catalog" flow ───────────────────────────────
+
+const MOCK_FRANCHISE_DETAIL = {
+  id: '550e8400-e29b-41d4-a716-446655440001',
+  slug: 'transformers',
+  name: 'Transformers',
+  sort_order: 1,
+  notes: 'Robots in disguise',
+  created_at: '2026-01-01T00:00:00Z',
+};
+
+const MOCK_ITEM_DETAIL = {
+  id: 'a0000000-0000-4000-a000-000000000001',
+  name: 'Legacy Bulkhead',
+  slug: 'legacy-bulkhead',
+  franchise: { slug: 'transformers', name: 'Transformers' },
+  characters: [
+    {
+      slug: 'bulkhead',
+      name: 'Bulkhead',
+      appearance_slug: 'animated',
+      appearance_name: 'Animated',
+      appearance_source_media: 'Animated Series',
+      appearance_source_name: 'Transformers Animated',
+      is_primary: true,
+    },
+  ],
+  manufacturer: { slug: 'hasbro', name: 'Hasbro' },
+  toy_line: { slug: 'legacy', name: 'Legacy' },
+  thumbnail_url: null,
+  size_class: 'Voyager',
+  year_released: 2023,
+  is_third_party: false,
+  data_quality: 'verified',
+  description: 'A great figure',
+  barcode: null,
+  sku: null,
+  product_code: null,
+  photos: [],
+  metadata: {},
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+};
+
+/**
+ * Install catalog route mocks needed for the "add from catalog" item detail page.
+ * The item detail page fetches: franchise detail, item detail, character detail,
+ * relationships, and collection check (handled by MockCollectionState).
+ */
+export async function setupCatalogForAddFlow(page: Page): Promise<void> {
+  // Catch-all for unhandled catalog requests
+  await page.route('**/catalog/**', (route) => {
+    if (isDocRequest(route)) return route.continue();
+    return route.fulfill(jsonResponse({ data: [] }));
+  });
+
+  // Relationships endpoint (item detail page fetches this)
+  await page.route('**/relationships', (route) => {
+    if (isDocRequest(route)) return route.continue();
+    return route.fulfill(jsonResponse({ relationships: [] }));
+  });
+
+  // Character detail (fetched by ItemDetailPage for the primary character)
+  await page.route('**/catalog/franchises/transformers/characters/**', (route) => {
+    if (isDocRequest(route)) return route.continue();
+    return route.fulfill(
+      jsonResponse({
+        id: 'c0000000-0000-4000-a000-000000000001',
+        slug: 'bulkhead',
+        name: 'Bulkhead',
+        franchise: { slug: 'transformers', name: 'Transformers' },
+        faction: { slug: 'autobots', name: 'Autobots' },
+        continuity_family: { slug: 'animated', name: 'Animated' },
+        character_type: null,
+        alt_mode: 'SWAT Vehicle',
+        is_combined_form: false,
+        sub_groups: [],
+        appearances: [
+          { slug: 'animated', name: 'Animated', source_media: 'Animated Series', source_name: 'Transformers Animated' },
+        ],
+        metadata: {},
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+      })
+    );
+  });
+
+  // Franchise detail
+  await page.route('**/catalog/franchises/transformers', (route) => {
+    if (isDocRequest(route)) return route.continue();
+    if (route.request().url().includes('/items') || route.request().url().includes('/characters'))
+      return route.fallback();
+    return route.fulfill(jsonResponse(MOCK_FRANCHISE_DETAIL));
+  });
+
+  // Item detail — matches /items/<slug> but not /items/facets
+  await page.route('**/catalog/franchises/transformers/items/**', (route) => {
+    if (isDocRequest(route)) return route.continue();
+    return route.fulfill(jsonResponse(MOCK_ITEM_DETAIL));
+  });
+}

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -49,7 +49,7 @@ export default defineConfig({
       name: 'user',
       use: { ...devices['Desktop Chrome'] },
       testMatch:
-        /authenticated-session\.spec\.ts|catalog-browse\.spec\.ts|catalog-detail-pages\.spec\.ts|catalog-search\.spec\.ts|session-persistence\.spec\.ts/,
+        /authenticated-session\.spec\.ts|catalog-browse\.spec\.ts|catalog-detail-pages\.spec\.ts|catalog-search\.spec\.ts|session-persistence\.spec\.ts|collection\.spec\.ts/,
     },
     // Authenticated as admin — admin dashboard
     {


### PR DESCRIPTION
## Summary

- Add 12 Playwright E2E tests covering all collection management user flows (empty state, dashboard stats, add from catalog, multiple copies, filtering, edit/remove with undo, view toggle, navigation)
- Introduce `MockCollectionState` class — stateful mock infrastructure for mutation chain testing
- Fix 7 pre-existing E2E failures in catalog specs (missing `thumbnail_url` + collection endpoint mocks)

## Test plan

- [x] All 12 collection E2E tests pass (`npx playwright test collection.spec.ts`)
- [x] Full E2E suite passes (58 passed, 1 pre-existing skip)
- [x] API checks pass (tests, lint, typecheck, format, build)
- [x] Web checks pass (tests, lint, typecheck, format, build)

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)