### PR TITLE
feat(web): compact detail sheet layout, fixes, and UX improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ web/e2e/.auth/*.json
 
 # Skill evaluation workspaces (generated test outputs, not part of the skill)
 .claude/skills/*-workspace/
+.playwright-mcp/console-2026-03-25T20-26-24-959Z.log

--- a/changelog/2026-03-25T223832Z_compact-detail-sheet-layout.md
+++ b/changelog/2026-03-25T223832Z_compact-detail-sheet-layout.md
@@ -1,0 +1,154 @@
+# Compact Detail Sheet Layout, Sheet Dismiss Fix, Collection Share Links
+
+**Date:** 2026-03-25
+**Time:** 22:38:32 UTC
+**Type:** Feature
+
+## Summary
+
+Redesigned item and character detail sheet layouts for better information density using 2-column CSS grids, reorganized header areas with tag chips and collection status, and fixed a Radix Dialog bug where non-modal sheets would close when list items received focus. Also made franchise/manufacturer table rows fully clickable and migrated collection page item selection to URL search params for shareable links.
+
+---
+
+## Changes Implemented
+
+### 1. Multi-Column Property Grids
+
+Replaced single-column `space-y-3` stacked layouts with `grid grid-cols-2 gap-x-6 gap-y-3` CSS grids in both item and character detail sheets, roughly halving vertical space for properties.
+
+- **Item grid columns:** Appearance | Manufacturer, Size Class | Toy Line, Year Released | Product Code
+- **Character grid columns:** Faction | Character Type, Sub-Groups (comma text) | Alt Mode
+- Year Released and Size Class always display (em dash when empty)
+- Description spans full width via `col-span-2`
+
+### 2. Sheet Header Reorganization
+
+Lifted metadata out of property grids into the sheet header area:
+
+- **Item sheet:** Title shows item name with character name as subtitle; data quality badge (now title-cased) and third-party badge as tag chips; "In Collection (N)" badge grouped with Add to Collection button, right-aligned via new `tagAction` slot
+- **Character sheet:** Franchise + Continuity + Combined Form as tag chips below the heading (in both standalone sheet and embedded section within item sheet)
+- **Character detail page:** Same tag chips below heading, above separator
+- `DetailField` gained `className` prop for grid spanning; `DetailSheet` gained `subtitle`, `tags`, `tagAction` props
+- `AddToCollectionButton` simplified — inline "In collection" text removed (moved to header badge)
+- `CharacterDetailContent` gained `hideTags` prop to avoid duplication when parent renders chips
+
+### 3. Bug Fix: Non-Modal Sheet Closing on Outside Focus
+
+**Root cause:** Radix Dialog's `DismissableLayer` with `modal={false}` fires `onDismiss` when focus moves outside the dialog. The `CharacterList` `useEffect` calls `el.focus()` on the selected `<li>` when character data loads. If the selected character appeared in the filtered list, focus moved outside the sheet, triggering dismissal.
+
+**Symptom:** URLs like `?sub_group=headmasters&selected=fangry` would load the page, briefly open the sheet, then immediately close it and strip `selected` from the URL. Only happened when the selected character was present in the current filtered results.
+
+**Fix:** Added `onFocusOutside` and `onInteractOutside` with `preventDefault()` on `SheetPrimitive.Content` in `DetailSheet`. This is correct for non-modal side panels where the list behind should remain interactive. Close button and Escape key still work.
+
+### 4. Appearances Table Improvements
+
+- Year formatting simplified: single year shown without hyphen when start == end or only one year present (was `1984–` / `–1985` / `1986–1986`)
+- First column uses `ps-0` for flush-left alignment; Name column `w-1/2` to align Source with the right property column
+
+### 5. Two-Column Lists
+
+- `RelationshipSection` items (combiner components, partners, rivals) now use 2-column grid
+- Related Items list in character detail uses 2-column grid
+
+### 6. Clickable Table Rows
+
+`FranchiseTable` and `ManufacturerTable` rows are now fully clickable (entire row navigates), matching item and character list behavior. Previously only the name text was a link.
+
+### 7. Collection Page Shareable Links
+
+Migrated collection page item selection from React state (`useState`) to URL search params (`selected` + `selected_franchise`). The "Copy link" button now produces a URL that includes the selected item, making collection item detail sheets shareable and bookmarkable.
+
+**Modified:**
+
+- `web/src/catalog/components/AppearancesTable.tsx` — year formatting, column alignment
+- `web/src/catalog/components/CharacterDetailContent.tsx` — 2-col grid, tag chips, `hideTags` prop
+- `web/src/catalog/components/CharacterDetailSheet.tsx` — header tags for franchise/continuity/combined form
+- `web/src/catalog/components/DetailField.tsx` — `className` prop
+- `web/src/catalog/components/DetailSheet.tsx` — `subtitle`, `tags`, `tagAction` props; focus-outside fix
+- `web/src/catalog/components/FranchiseTable.tsx` — clickable rows via `useNavigate`
+- `web/src/catalog/components/ItemDetailContent.tsx` — 2-col grid, badges removed
+- `web/src/catalog/components/ItemDetailSheet.tsx` — header tags, collection badge, subtitle, tagAction
+- `web/src/catalog/components/ManufacturerTable.tsx` — clickable rows via `useNavigate`
+- `web/src/catalog/components/RelationshipSection.tsx` — 2-col grid
+- `web/src/catalog/pages/CharacterDetailPage.tsx` — tag chips below heading
+- `web/src/collection/components/AddToCollectionButton.tsx` — removed inline "In collection" text
+- `web/src/collection/pages/CollectionPage.tsx` — URL-based item selection
+- `web/src/routes/_authenticated/collection.tsx` — `selected`, `selected_franchise` search params
+
+**Tests updated:**
+
+- `web/src/catalog/components/__tests__/AppearancesTable.test.tsx` — year formatting tests updated, same-year case added
+- `web/src/catalog/components/__tests__/FranchiseTable.test.tsx` — link test replaced with row click navigation test
+- `web/src/catalog/components/__tests__/ItemDetailContent.test.tsx` — removed character link and badge tests (moved to sheet)
+- `web/src/catalog/components/__tests__/ItemDetailSheet.test.tsx` — added collection badge, data quality badge, third party badge, title/subtitle tests
+- `web/src/catalog/components/__tests__/ManufacturerTable.test.tsx` — link test replaced with row click navigation test
+- `web/src/catalog/pages/__tests__/FranchiseListPage.test.tsx` — added `useNavigate` mock for table component
+- `web/src/catalog/pages/__tests__/ManufacturerListPage.test.tsx` — added `useNavigate` mock for table component
+- `web/src/collection/components/__tests__/AddToCollectionButton.test.tsx` — removed "In collection" text assertion
+
+---
+
+## Technical Details
+
+### CSS Grid for Property Layout
+
+```tsx
+<dl className="grid grid-cols-2 gap-x-6 gap-y-3">
+  <DetailField label="Faction" value={data.faction?.name} />
+  <DetailField label="Character Type" value={data.character_type} />
+  ...
+</dl>
+```
+
+CSS Grid auto-placement fills cells left-to-right, top-to-bottom. When optional fields are absent (`DetailField` returns `null`), remaining fields flow naturally without empty gaps.
+
+### Radix DismissableLayer Fix
+
+```tsx
+<SheetPrimitive.Content
+  onFocusOutside={(e) => e.preventDefault()}
+  onInteractOutside={(e) => e.preventDefault()}
+>
+```
+
+Radix Dialog's `Content` component exposes `onFocusOutside` and `onInteractOutside` handlers that fire before the dismiss logic. Calling `preventDefault()` suppresses the dismissal while preserving all other Radix behavior (Escape key, close button, `onOpenChange`).
+
+---
+
+## Validation & Testing
+
+```
+> eslint .          ✅ 0 errors
+> tsc -b            ✅ clean
+> vitest run        ✅ 91 files, 687 tests passed
+```
+
+- Sheet dismiss fix verified with Playwright: `?sub_group=headmasters&selected=fangry` now keeps the sheet open
+- Tests updated across 8 test files (new badge tests, navigation tests, year format tests)
+
+---
+
+## Impact Assessment
+
+- **Information density:** Item and character sheets show properties in roughly half the vertical space
+- **Navigation consistency:** Franchise/manufacturer tables now match item/character list click behavior
+- **Shareability:** Collection page item detail links are now bookmarkable and shareable
+- **Bug fix:** Eliminates a class of Radix Dialog dismiss bugs for all non-modal detail sheets
+
+---
+
+## Summary Statistics
+
+| Metric | Value |
+|--------|-------|
+| Files changed | 22 |
+| Lines added | 274 |
+| Lines removed | 180 |
+| Tests passing | 687 |
+| Test files | 91 |
+
+---
+
+## Status
+
+✅ COMPLETE — Lint, typecheck, and all tests passing.

--- a/web/src/catalog/components/AppearancesTable.tsx
+++ b/web/src/catalog/components/AppearancesTable.tsx
@@ -7,9 +7,11 @@ interface AppearancesTableProps {
 
 function formatYears(yearStart: number | null, yearEnd: number | null): string {
   if (yearStart === null && yearEnd === null) return '—';
-  if (yearStart !== null && yearEnd !== null) return `${yearStart}–${yearEnd}`;
-  if (yearStart !== null) return `${yearStart}–`;
-  return `–${yearEnd}`;
+  if (yearStart !== null && yearEnd !== null) {
+    return yearStart === yearEnd ? `${yearStart}` : `${yearStart}–${yearEnd}`;
+  }
+  if (yearStart !== null) return `${yearStart}`;
+  return `${yearEnd}`;
 }
 
 export function AppearancesTable({ appearances }: AppearancesTableProps) {
@@ -21,7 +23,7 @@ export function AppearancesTable({ appearances }: AppearancesTableProps) {
     <Table>
       <TableHeader>
         <TableRow>
-          <TableHead>Name</TableHead>
+          <TableHead className="w-1/2 ps-0">Name</TableHead>
           <TableHead>Source</TableHead>
           <TableHead>Years</TableHead>
         </TableRow>
@@ -29,7 +31,7 @@ export function AppearancesTable({ appearances }: AppearancesTableProps) {
       <TableBody>
         {appearances.map((appearance) => (
           <TableRow key={appearance.id}>
-            <TableCell className="font-medium">{appearance.name}</TableCell>
+            <TableCell className="font-medium ps-0">{appearance.name}</TableCell>
             <TableCell>{appearance.source_media ?? '—'}</TableCell>
             <TableCell className="tabular-nums">{formatYears(appearance.year_start, appearance.year_end)}</TableCell>
           </TableRow>

--- a/web/src/catalog/components/CharacterDetailContent.tsx
+++ b/web/src/catalog/components/CharacterDetailContent.tsx
@@ -9,44 +9,39 @@ interface CharacterDetailContentProps {
   data: CharacterDetail;
   relatedItems?: CatalogItem[];
   relatedItemsCount?: number;
+  hideTags?: boolean;
 }
 
-export function CharacterDetailContent({ data, relatedItems, relatedItemsCount }: CharacterDetailContentProps) {
+export function CharacterDetailContent({ data, relatedItems, relatedItemsCount, hideTags }: CharacterDetailContentProps) {
   const franchise = data.franchise.slug;
 
   return (
     <>
-      <dl className="space-y-3">
-        <DetailField label="Franchise" value={data.franchise.name} />
-        {data.faction && <DetailField label="Faction" value={data.faction.name} />}
-        <DetailField label="Continuity" value={data.continuity_family.name} />
-        <DetailField label="Character Type" value={data.character_type} />
-        <DetailField label="Alt Mode" value={data.alt_mode} />
-
-        {data.is_combined_form && (
-          <div>
+      {!hideTags && (
+        <div className="flex flex-wrap items-center gap-1.5 mb-3">
+          <Badge variant="secondary">{data.franchise.name}</Badge>
+          <Badge variant="secondary">{data.continuity_family.name}</Badge>
+          {data.is_combined_form && (
             <Badge
               variant="outline"
               className="border-orange-300 text-orange-700 dark:border-orange-700 dark:text-orange-300"
             >
               Combined Form
             </Badge>
-          </div>
-        )}
-      </dl>
-
-      {data.sub_groups.length > 0 && (
-        <section className="mt-6">
-          <h3 className="text-sm font-semibold text-foreground mb-2">Sub-Groups</h3>
-          <div className="flex flex-wrap gap-1.5">
-            {data.sub_groups.map((sg) => (
-              <Badge key={sg.slug} variant="secondary">
-                {sg.name}
-              </Badge>
-            ))}
-          </div>
-        </section>
+          )}
+        </div>
       )}
+
+      <dl className="grid grid-cols-2 gap-x-6 gap-y-3">
+        <DetailField label="Faction" value={data.faction?.name} />
+        <DetailField label="Character Type" value={data.character_type} />
+
+        <DetailField
+          label="Sub-Groups"
+          value={data.sub_groups.length > 0 ? data.sub_groups.map((sg) => sg.name).join(', ') : undefined}
+        />
+        <DetailField label="Alt Mode" value={data.alt_mode} />
+      </dl>
 
       <CharacterRelationships franchise={franchise} characterSlug={data.slug} />
 
@@ -58,7 +53,7 @@ export function CharacterDetailContent({ data, relatedItems, relatedItemsCount }
       {relatedItems && relatedItems.length > 0 && (
         <section className="mt-6">
           <h3 className="text-sm font-semibold text-foreground mb-2">Related Items</h3>
-          <ul className="space-y-1.5">
+          <ul className="grid grid-cols-2 gap-x-6 gap-y-1.5">
             {relatedItems.map((item) => (
               <li key={item.id}>
                 <Link

--- a/web/src/catalog/components/CharacterDetailSheet.tsx
+++ b/web/src/catalog/components/CharacterDetailSheet.tsx
@@ -1,3 +1,4 @@
+import { Badge } from '@/components/ui/badge';
 import { useCharacterDetail } from '@/catalog/hooks/useCharacterDetail';
 import { CharacterDetailContent } from '@/catalog/components/CharacterDetailContent';
 import { DetailSheet } from '@/catalog/components/DetailSheet';
@@ -23,8 +24,24 @@ export function CharacterDetailSheet({ franchise, characterSlug, onClose }: Char
       isPending={isPending}
       isError={isError}
       actions={<ShareLinkButton />}
+      tags={
+        data && (
+          <>
+            <Badge variant="secondary">{data.franchise.name}</Badge>
+            <Badge variant="secondary">{data.continuity_family.name}</Badge>
+            {data.is_combined_form && (
+              <Badge
+                variant="outline"
+                className="border-orange-300 text-orange-700 dark:border-orange-700 dark:text-orange-300"
+              >
+                Combined Form
+              </Badge>
+            )}
+          </>
+        )
+      }
     >
-      {data && <CharacterDetailContent data={data} />}
+      {data && <CharacterDetailContent data={data} hideTags />}
     </DetailSheet>
   );
 }

--- a/web/src/catalog/components/DetailField.tsx
+++ b/web/src/catalog/components/DetailField.tsx
@@ -1,15 +1,17 @@
 import type { ReactNode } from 'react';
+import { cn } from '@/lib/utils';
 
 interface DetailFieldProps {
   label: string;
   value?: string | null | undefined;
   children?: ReactNode;
+  className?: string;
 }
 
-export function DetailField({ label, value, children }: DetailFieldProps) {
+export function DetailField({ label, value, children, className }: DetailFieldProps) {
   if (!children && !value) return null;
   return (
-    <div>
+    <div className={cn(className)}>
       <dt className="text-xs font-medium uppercase tracking-wider text-muted-foreground">{label}</dt>
       <dd className="text-sm mt-0.5">{children ?? value}</dd>
     </div>

--- a/web/src/catalog/components/DetailSheet.tsx
+++ b/web/src/catalog/components/DetailSheet.tsx
@@ -11,9 +11,12 @@ interface DetailSheetProps {
   onOpenChange: (open: boolean) => void;
   entityType: string;
   title: string | undefined;
+  subtitle?: string;
   isPending: boolean;
   isError: boolean;
   actions?: ReactNode;
+  tags?: ReactNode;
+  tagAction?: ReactNode;
   children: ReactNode;
 }
 
@@ -22,9 +25,12 @@ export function DetailSheet({
   onOpenChange,
   entityType,
   title,
+  subtitle,
   isPending,
   isError,
   actions,
+  tags,
+  tagAction,
   children,
 }: DetailSheetProps) {
   return (
@@ -33,10 +39,13 @@ export function DetailSheet({
         <SheetPrimitive.Content
           aria-label={`${entityType} detail`}
           className={cn(sheetVariants({ side: 'right' }), 'sm:max-w-3xl w-full flex flex-col')}
+          onFocusOutside={(e) => e.preventDefault()}
+          onInteractOutside={(e) => e.preventDefault()}
         >
           <div className="flex items-start justify-between gap-2">
-            <div className="flex flex-col space-y-1.5 min-w-0">
+            <div className="flex flex-col min-w-0">
               <SheetTitle className="truncate">{isPending ? '\u00A0' : title}</SheetTitle>
+              {subtitle && <p className="text-sm text-muted-foreground truncate">{subtitle}</p>}
               <SheetDescription className="sr-only">{entityType} details</SheetDescription>
             </div>
             <div className="flex items-center gap-1 flex-shrink-0">
@@ -47,7 +56,14 @@ export function DetailSheet({
             </div>
           </div>
 
-          <Separator className="my-4" />
+          {(tags || tagAction) && (
+            <div className="flex items-center gap-1.5">
+              <div className="flex flex-wrap items-center gap-1.5 flex-1">{tags}</div>
+              {tagAction && <div className="flex-shrink-0">{tagAction}</div>}
+            </div>
+          )}
+
+          <Separator className="my-3" />
 
           <div className="flex-1 overflow-y-auto">
             {isPending && (

--- a/web/src/catalog/components/FranchiseTable.tsx
+++ b/web/src/catalog/components/FranchiseTable.tsx
@@ -1,4 +1,4 @@
-import { Link } from '@tanstack/react-router';
+import { useNavigate } from '@tanstack/react-router';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import type { FranchiseStatsItem } from '@/lib/zod-schemas';
 
@@ -7,6 +7,8 @@ interface FranchiseTableProps {
 }
 
 export function FranchiseTable({ franchises }: FranchiseTableProps) {
+  const navigate = useNavigate();
+
   return (
     <div className="rounded-md border">
       <Table>
@@ -21,16 +23,14 @@ export function FranchiseTable({ franchises }: FranchiseTableProps) {
         </TableHeader>
         <TableBody>
           {franchises.map((f) => (
-            <TableRow key={f.slug}>
-              <TableCell>
-                <Link
-                  to="/catalog/$franchise"
-                  params={{ franchise: f.slug }}
-                  className="text-sm font-medium text-foreground hover:text-primary transition-colors"
-                >
-                  {f.name}
-                </Link>
-              </TableCell>
+            <TableRow
+              key={f.slug}
+              className="cursor-pointer"
+              onClick={() => {
+                void navigate({ to: '/catalog/$franchise', params: { franchise: f.slug } });
+              }}
+            >
+              <TableCell className="text-sm font-medium text-foreground">{f.name}</TableCell>
               <TableCell className="text-right tabular-nums text-sm">{f.item_count}</TableCell>
               <TableCell className="text-right tabular-nums text-sm">{f.continuity_family_count}</TableCell>
               <TableCell className="text-right tabular-nums text-sm">{f.manufacturer_count}</TableCell>

--- a/web/src/catalog/components/ItemDetailContent.tsx
+++ b/web/src/catalog/components/ItemDetailContent.tsx
@@ -1,7 +1,5 @@
 import { Link } from '@tanstack/react-router';
-import { Badge } from '@/components/ui/badge';
 import { DetailField } from '@/catalog/components/DetailField';
-import { dataQualityStyle } from '@/catalog/components/data-quality-style';
 import { PhotoGallery } from '@/catalog/components/PhotoGallery';
 import { ItemRelationships } from '@/catalog/components/ItemRelationships';
 import type { CatalogItemDetail } from '@/lib/zod-schemas';
@@ -18,18 +16,8 @@ export function ItemDetailContent({ data, franchise }: ItemDetailContentProps) {
     <>
       <PhotoGallery photos={data.photos} itemName={data.name} />
 
-      <dl className="space-y-3">
-        {primary && (
-          <DetailField label="Character">
-            <Link
-              to="/catalog/$franchise/characters/$slug"
-              params={{ franchise, slug: primary.slug }}
-              className="text-primary hover:underline"
-            >
-              {primary.name}
-            </Link>
-          </DetailField>
-        )}
+      <dl className="grid grid-cols-2 gap-x-6 gap-y-3">
+        {primary?.appearance_name && <DetailField label="Appearance" value={primary.appearance_name} />}
 
         {data.manufacturer && (
           <DetailField label="Manufacturer">
@@ -43,6 +31,8 @@ export function ItemDetailContent({ data, franchise }: ItemDetailContentProps) {
           </DetailField>
         )}
 
+        <DetailField label="Size Class" value={data.size_class ?? '—'} />
+
         <DetailField label="Toy Line">
           <Link
             to="/catalog/$franchise/items"
@@ -54,30 +44,14 @@ export function ItemDetailContent({ data, franchise }: ItemDetailContentProps) {
           </Link>
         </DetailField>
 
-        <DetailField label="Size Class" value={data.size_class} />
-        <DetailField label="Year Released" value={data.year_released?.toString()} />
+        <DetailField label="Year Released" value={data.year_released?.toString() ?? '—'} />
         <DetailField label="Product Code" value={data.product_code} />
 
-        {primary?.appearance_name && <DetailField label="Appearance" value={primary.appearance_name} />}
-
-        <DetailField label="Status">
-          <Badge variant="outline" className={dataQualityStyle(data.data_quality)}>
-            {data.data_quality.replace(/_/g, ' ')}
-          </Badge>
-        </DetailField>
-
-        {data.is_third_party && (
-          <div>
-            <Badge
-              variant="outline"
-              className="border-purple-300 text-purple-700 dark:border-purple-700 dark:text-purple-300"
-            >
-              Third Party
-            </Badge>
-          </div>
+        {data.description && (
+          <DetailField label="Description" className="col-span-2">
+            {data.description}
+          </DetailField>
         )}
-
-        {data.description && <DetailField label="Description">{data.description}</DetailField>}
       </dl>
 
       <ItemRelationships franchise={franchise} itemSlug={data.slug} />

--- a/web/src/catalog/components/ItemDetailSheet.tsx
+++ b/web/src/catalog/components/ItemDetailSheet.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react';
 import { Link } from '@tanstack/react-router';
 import { Camera } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
 import { Button } from '@/components/ui/button';
 import { useItemDetail } from '@/catalog/hooks/useItemDetail';
@@ -9,6 +10,7 @@ import { ItemDetailContent } from '@/catalog/components/ItemDetailContent';
 import { CharacterDetailContent } from '@/catalog/components/CharacterDetailContent';
 import { DetailSheet } from '@/catalog/components/DetailSheet';
 import { ShareLinkButton } from '@/catalog/components/ShareLinkButton';
+import { dataQualityStyle } from '@/catalog/components/data-quality-style';
 import { PhotoManagementSheet } from '@/catalog/photos/PhotoManagementSheet';
 import { AddToCollectionButton } from '@/collection/components/AddToCollectionButton';
 import { useCollectionCheck } from '@/collection/hooks/useCollectionCheck';
@@ -28,12 +30,16 @@ export function ItemDetailSheet({ franchise, itemSlug, onClose }: ItemDetailShee
 
   const { data, isPending, isError } = useItemDetail(franchise, itemSlug);
 
-  const primaryCharacterSlug = data?.characters.find((c) => c.is_primary)?.slug ?? data?.characters[0]?.slug;
-  const { data: characterData } = useCharacterDetail(franchise, primaryCharacterSlug);
+  const primaryCharacter = data?.characters.find((c) => c.is_primary) ?? data?.characters[0];
+  const { data: characterData } = useCharacterDetail(franchise, primaryCharacter?.slug);
+
+  const sheetTitle = data?.name;
+  const sheetSubtitle = primaryCharacter?.name;
 
   const itemIds = useMemo(() => (data?.id ? [data.id] : []), [data?.id]);
   const { data: checkData } = useCollectionCheck(itemIds);
   const checkEntry = data?.id ? checkData?.items[data.id] : undefined;
+  const collectionCount = checkEntry?.count ?? 0;
   const collectionMutations = useCollectionMutations();
 
   return (
@@ -43,7 +49,8 @@ export function ItemDetailSheet({ franchise, itemSlug, onClose }: ItemDetailShee
         if (!open) onClose();
       }}
       entityType="Item"
-      title={data?.name}
+      title={sheetTitle}
+      subtitle={sheetSubtitle}
       isPending={isPending}
       isError={isError}
       actions={
@@ -56,24 +63,54 @@ export function ItemDetailSheet({ franchise, itemSlug, onClose }: ItemDetailShee
           <ShareLinkButton />
         </>
       }
-    >
-      {data && (
-        <>
-          <ItemDetailContent data={data} franchise={franchise} />
-
-          <div className="mt-4">
+      tags={
+        data && (
+          <>
+            <Badge variant="outline" className={dataQualityStyle(data.data_quality)}>
+              {data.data_quality
+                .replace(/_/g, ' ')
+                .replace(/\b\w/g, (c) => c.toUpperCase())}
+            </Badge>
+            {data.is_third_party && (
+              <Badge
+                variant="outline"
+                className="border-purple-300 text-purple-700 dark:border-purple-700 dark:text-purple-300"
+              >
+                Third Party
+              </Badge>
+            )}
+          </>
+        )
+      }
+      tagAction={
+        data && (
+          <div className="flex items-center gap-3">
+            {collectionCount > 0 && (
+              <Badge
+                variant="outline"
+                className="border-amber-300 text-amber-700 dark:border-amber-700 dark:text-amber-400"
+              >
+                In Collection ({collectionCount})
+              </Badge>
+            )}
             <AddToCollectionButton
               item={{ id: data.id, name: data.name }}
               checkResult={checkEntry}
               mutations={collectionMutations}
             />
           </div>
+        )
+      }
+    >
+      {data && (
+        <>
+          <ItemDetailContent data={data} franchise={franchise} />
 
           {characterData && (
             <>
               <Separator className="my-6" />
               <section>
-                <h3 className="text-lg font-semibold text-foreground mb-4">
+                <h3 className="text-lg font-semibold text-foreground">
                   <Link
                     to="/catalog/$franchise/characters/$slug"
                     params={{ franchise, slug: characterData.slug }}
@@ -82,7 +119,19 @@ export function ItemDetailSheet({ franchise, itemSlug, onClose }: ItemDetailShee
                     {characterData.name}
                   </Link>
                 </h3>
-                <CharacterDetailContent data={characterData} />
+                <div className="flex flex-wrap items-center gap-1.5 mt-1 mb-4">
+                  <Badge variant="secondary">{characterData.franchise.name}</Badge>
+                  <Badge variant="secondary">{characterData.continuity_family.name}</Badge>
+                  {characterData.is_combined_form && (
+                    <Badge
+                      variant="outline"
+                      className="border-orange-300 text-orange-700 dark:border-orange-700 dark:text-orange-300"
+                    >
+                      Combined Form
+                    </Badge>
+                  )}
+                </div>
+                <CharacterDetailContent data={characterData} hideTags />
               </section>
             </>
           )}

--- a/web/src/catalog/components/ManufacturerTable.tsx
+++ b/web/src/catalog/components/ManufacturerTable.tsx
@@ -1,4 +1,4 @@
-import { Link } from '@tanstack/react-router';
+import { useNavigate } from '@tanstack/react-router';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import type { ManufacturerStatsItem } from '@/lib/zod-schemas';
 
@@ -7,6 +7,8 @@ interface ManufacturerTableProps {
 }
 
 export function ManufacturerTable({ manufacturers }: ManufacturerTableProps) {
+  const navigate = useNavigate();
+
   return (
     <div className="rounded-md border">
       <Table aria-label="Manufacturers list">
@@ -20,16 +22,14 @@ export function ManufacturerTable({ manufacturers }: ManufacturerTableProps) {
         </TableHeader>
         <TableBody>
           {manufacturers.map((m) => (
-            <TableRow key={m.slug}>
-              <TableCell>
-                <Link
-                  to="/catalog/manufacturers/$slug"
-                  params={{ slug: m.slug }}
-                  className="text-sm font-medium text-foreground hover:text-primary transition-colors"
-                >
-                  {m.name}
-                </Link>
-              </TableCell>
+            <TableRow
+              key={m.slug}
+              className="cursor-pointer"
+              onClick={() => {
+                void navigate({ to: '/catalog/manufacturers/$slug', params: { slug: m.slug } });
+              }}
+            >
+              <TableCell className="text-sm font-medium text-foreground">{m.name}</TableCell>
               <TableCell className="text-right tabular-nums text-sm">{m.item_count}</TableCell>
               <TableCell className="text-right tabular-nums text-sm">{m.toy_line_count}</TableCell>
               <TableCell className="text-right tabular-nums text-sm">{m.franchise_count}</TableCell>

--- a/web/src/catalog/components/RelationshipSection.tsx
+++ b/web/src/catalog/components/RelationshipSection.tsx
@@ -37,7 +37,7 @@ export function RelationshipSection({ groups }: RelationshipSectionProps) {
               </Badge>
             )}
           </h3>
-          <ul className="space-y-1.5">
+          <ul className="grid grid-cols-2 gap-x-6 gap-y-1.5">
             {group.items.map((item) => (
               <li key={item.key}>
                 {item.isCurrent ? (

--- a/web/src/catalog/components/__tests__/AppearancesTable.test.tsx
+++ b/web/src/catalog/components/__tests__/AppearancesTable.test.tsx
@@ -27,14 +27,19 @@ describe('AppearancesTable', () => {
     expect(screen.getByText('1984–1985')).toBeInTheDocument();
   });
 
-  it('formats open-ended start year as "1984–"', () => {
+  it('formats start-only year without hyphen', () => {
     render(<AppearancesTable appearances={[{ ...mockAppearance, year_end: null }]} />);
-    expect(screen.getByText('1984–')).toBeInTheDocument();
+    expect(screen.getByText('1984')).toBeInTheDocument();
   });
 
-  it('formats open-ended end year as "–1985"', () => {
+  it('formats end-only year without hyphen', () => {
     render(<AppearancesTable appearances={[{ ...mockAppearance, year_start: null }]} />);
-    expect(screen.getByText('–1985')).toBeInTheDocument();
+    expect(screen.getByText('1985')).toBeInTheDocument();
+  });
+
+  it('formats same start and end year as single year', () => {
+    render(<AppearancesTable appearances={[{ ...mockAppearance, year_start: 1986, year_end: 1986 }]} />);
+    expect(screen.getByText('1986')).toBeInTheDocument();
   });
 
   it('formats null/null years as "—"', () => {

--- a/web/src/catalog/components/__tests__/FranchiseTable.test.tsx
+++ b/web/src/catalog/components/__tests__/FranchiseTable.test.tsx
@@ -1,16 +1,12 @@
-import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { FranchiseTable } from '../FranchiseTable';
 import { mockFranchise } from '@/catalog/__tests__/catalog-test-helpers';
 import type { FranchiseStatsItem } from '@/lib/zod-schemas';
 
+const mockNavigate = vi.fn();
 vi.mock('@tanstack/react-router', () => ({
-  Link: ({ children, to, ...props }: { children: React.ReactNode; to: string }) => (
-    <a href={to} {...props}>
-      {children}
-    </a>
-  ),
+  useNavigate: () => mockNavigate,
 }));
 
 const mockFranchises: FranchiseStatsItem[] = [
@@ -36,10 +32,11 @@ describe('FranchiseTable', () => {
     expect(screen.getByText('Notes')).toBeInTheDocument();
   });
 
-  it('renders franchise name as a link', () => {
+  it('renders franchise name and navigates on row click', () => {
     render(<FranchiseTable franchises={mockFranchises} />);
-    const link = screen.getByText('Transformers').closest('a');
-    expect(link).toHaveAttribute('href', '/catalog/$franchise');
+    expect(screen.getByText('Transformers')).toBeInTheDocument();
+    screen.getByText('Transformers').closest('tr')!.click();
+    expect(mockNavigate).toHaveBeenCalledWith({ to: '/catalog/$franchise', params: { franchise: 'transformers' } });
   });
 
   it('renders count columns', () => {

--- a/web/src/catalog/components/__tests__/ItemDetailContent.test.tsx
+++ b/web/src/catalog/components/__tests__/ItemDetailContent.test.tsx
@@ -18,12 +18,6 @@ vi.mock('@/catalog/components/ItemRelationships', () => ({
 }));
 
 describe('ItemDetailContent', () => {
-  it('renders character link', () => {
-    render(<ItemDetailContent data={mockCatalogItemDetail} franchise="transformers" />);
-    const link = screen.getByText('Optimus Prime').closest('a');
-    expect(link).toHaveAttribute('href', '/catalog/$franchise/characters/$slug');
-  });
-
   it('renders manufacturer link when present', () => {
     render(<ItemDetailContent data={mockCatalogItemDetail} franchise="transformers" />);
     const link = screen.getByText('Hasbro').closest('a');
@@ -68,22 +62,6 @@ describe('ItemDetailContent', () => {
     const data: CatalogItemDetail = { ...mockCatalogItemDetail, characters: [] };
     render(<ItemDetailContent data={data} franchise="transformers" />);
     expect(screen.queryByText('Appearance')).not.toBeInTheDocument();
-  });
-
-  it('renders data_quality badge', () => {
-    render(<ItemDetailContent data={mockCatalogItemDetail} franchise="transformers" />);
-    expect(screen.getByText('verified')).toBeInTheDocument();
-  });
-
-  it('renders "Third Party" badge when is_third_party is true', () => {
-    const data: CatalogItemDetail = { ...mockCatalogItemDetail, is_third_party: true };
-    render(<ItemDetailContent data={data} franchise="transformers" />);
-    expect(screen.getByText('Third Party')).toBeInTheDocument();
-  });
-
-  it('does not render "Third Party" badge when false', () => {
-    render(<ItemDetailContent data={mockCatalogItemDetail} franchise="transformers" />);
-    expect(screen.queryByText('Third Party')).not.toBeInTheDocument();
   });
 
   it('renders description when present', () => {

--- a/web/src/catalog/components/__tests__/ItemDetailSheet.test.tsx
+++ b/web/src/catalog/components/__tests__/ItemDetailSheet.test.tsx
@@ -20,8 +20,9 @@ vi.mock('@/catalog/components/CharacterRelationships', () => ({
   CharacterRelationships: () => null,
 }));
 
+const mockCollectionCheckData = vi.fn();
 vi.mock('@/collection/hooks/useCollectionCheck', () => ({
-  useCollectionCheck: () => ({ data: undefined }),
+  useCollectionCheck: () => ({ data: mockCollectionCheckData() }),
 }));
 
 vi.mock('@/collection/hooks/useCollectionMutations', () => ({
@@ -62,6 +63,7 @@ describe('ItemDetailSheet', () => {
     Object.assign(navigator, { clipboard: { writeText: vi.fn().mockResolvedValue(undefined) } });
     mockUseAuth.mockReturnValue({ user: { id: 'u-1', role: 'user' }, isAuthenticated: true, isLoading: false });
     mockUseCharacterDetail.mockReturnValue({ data: undefined, isPending: false, isError: false });
+    mockCollectionCheckData.mockReturnValue(undefined);
   });
 
   it('renders no dialog when itemSlug is undefined', () => {
@@ -82,12 +84,11 @@ describe('ItemDetailSheet', () => {
     expect(screen.getByText('Failed to load Item details.')).toBeInTheDocument();
   });
 
-  it('renders item name in sheet title when data loads', () => {
+  it('renders item name as title and character name as subtitle when data loads', () => {
     mockUseItemDetail.mockReturnValue({ data: mockCatalogItemDetail, isPending: false, isError: false });
     render(<ItemDetailSheet franchise="transformers" itemSlug="optimus-prime" onClose={vi.fn()} />);
     const dialog = screen.getByRole('dialog');
     expect(dialog).toHaveAttribute('aria-label', 'Item detail');
-    // Item name renders in the sheet (may appear multiple times if character shares the name)
     expect(screen.getAllByText('Optimus Prime').length).toBeGreaterThanOrEqual(1);
   });
 
@@ -125,5 +126,39 @@ describe('ItemDetailSheet', () => {
     mockUseItemDetail.mockReturnValue({ data: mockCatalogItemDetail, isPending: false, isError: false });
     render(<ItemDetailSheet franchise="transformers" itemSlug="optimus-prime" onClose={vi.fn()} />);
     expect(screen.getByRole('button', { name: 'Copy link' })).toBeInTheDocument();
+  });
+
+  it('renders data_quality badge in header tags', () => {
+    mockUseItemDetail.mockReturnValue({ data: mockCatalogItemDetail, isPending: false, isError: false });
+    render(<ItemDetailSheet franchise="transformers" itemSlug="optimus-prime" onClose={vi.fn()} />);
+    expect(screen.getByText('Verified')).toBeInTheDocument();
+  });
+
+  it('renders "Third Party" badge when is_third_party is true', () => {
+    const data = { ...mockCatalogItemDetail, is_third_party: true };
+    mockUseItemDetail.mockReturnValue({ data, isPending: false, isError: false });
+    render(<ItemDetailSheet franchise="transformers" itemSlug="optimus-prime" onClose={vi.fn()} />);
+    expect(screen.getByText('Third Party')).toBeInTheDocument();
+  });
+
+  it('does not render "Third Party" badge when false', () => {
+    mockUseItemDetail.mockReturnValue({ data: mockCatalogItemDetail, isPending: false, isError: false });
+    render(<ItemDetailSheet franchise="transformers" itemSlug="optimus-prime" onClose={vi.fn()} />);
+    expect(screen.queryByText('Third Party')).not.toBeInTheDocument();
+  });
+
+  it('renders "In Collection" badge when item is in collection', () => {
+    mockUseItemDetail.mockReturnValue({ data: mockCatalogItemDetail, isPending: false, isError: false });
+    mockCollectionCheckData.mockReturnValue({
+      items: { [mockCatalogItemDetail.id]: { count: 3, collection_ids: ['c-1', 'c-2', 'c-3'] } },
+    });
+    render(<ItemDetailSheet franchise="transformers" itemSlug="optimus-prime" onClose={vi.fn()} />);
+    expect(screen.getByText('In Collection (3)')).toBeInTheDocument();
+  });
+
+  it('does not render "In Collection" badge when not in collection', () => {
+    mockUseItemDetail.mockReturnValue({ data: mockCatalogItemDetail, isPending: false, isError: false });
+    render(<ItemDetailSheet franchise="transformers" itemSlug="optimus-prime" onClose={vi.fn()} />);
+    expect(screen.queryByText(/In Collection/)).not.toBeInTheDocument();
   });
 });

--- a/web/src/catalog/components/__tests__/ManufacturerTable.test.tsx
+++ b/web/src/catalog/components/__tests__/ManufacturerTable.test.tsx
@@ -1,15 +1,11 @@
-import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { ManufacturerTable } from '../ManufacturerTable';
 import { mockManufacturer } from '@/catalog/__tests__/catalog-test-helpers';
 
+const mockNavigate = vi.fn();
 vi.mock('@tanstack/react-router', () => ({
-  Link: ({ children, to, ...props }: { children: React.ReactNode; to: string }) => (
-    <a href={to} {...props}>
-      {children}
-    </a>
-  ),
+  useNavigate: () => mockNavigate,
 }));
 
 const mockManufacturers = [mockManufacturer];
@@ -28,10 +24,11 @@ describe('ManufacturerTable', () => {
     expect(screen.getByText('Franchises')).toBeInTheDocument();
   });
 
-  it('renders manufacturer name as a link', () => {
+  it('renders manufacturer name and navigates on row click', () => {
     render(<ManufacturerTable manufacturers={mockManufacturers} />);
-    const link = screen.getByText('Hasbro').closest('a');
-    expect(link).toHaveAttribute('href', '/catalog/manufacturers/$slug');
+    expect(screen.getByText('Hasbro')).toBeInTheDocument();
+    screen.getByText('Hasbro').closest('tr')!.click();
+    expect(mockNavigate).toHaveBeenCalledWith({ to: '/catalog/manufacturers/$slug', params: { slug: 'hasbro' } });
   });
 
   it('renders count columns', () => {

--- a/web/src/catalog/pages/CharacterDetailPage.tsx
+++ b/web/src/catalog/pages/CharacterDetailPage.tsx
@@ -5,6 +5,7 @@ import { Route } from '@/routes/_authenticated/catalog/$franchise/characters/$sl
 import { AppHeader } from '@/components/AppHeader';
 import { MainNav } from '@/components/MainNav';
 import { LoadingSpinner } from '@/components/LoadingSpinner';
+import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
 import { useCharacterDetail } from '@/catalog/hooks/useCharacterDetail';
 import { useFranchiseDetail } from '@/catalog/hooks/useFranchiseDetail';
@@ -101,9 +102,22 @@ export function CharacterDetailPage() {
 
         {data && (
           <div className="max-w-2xl">
-            <div className="flex items-start justify-between gap-2 mb-4">
+            <div className="flex items-start justify-between gap-2">
               <h1 className="text-2xl font-semibold text-foreground">{data.name}</h1>
               <ShareLinkButton />
+            </div>
+
+            <div className="flex flex-wrap items-center gap-1.5 mt-1 mb-4">
+              <Badge variant="secondary">{data.franchise.name}</Badge>
+              <Badge variant="secondary">{data.continuity_family.name}</Badge>
+              {data.is_combined_form && (
+                <Badge
+                  variant="outline"
+                  className="border-orange-300 text-orange-700 dark:border-orange-700 dark:text-orange-300"
+                >
+                  Combined Form
+                </Badge>
+              )}
             </div>
 
             <Separator className="mb-6" />
@@ -112,6 +126,7 @@ export function CharacterDetailPage() {
               data={data}
               relatedItems={itemsData?.data}
               relatedItemsCount={itemsData?.total_count}
+              hideTags
             />
           </div>
         )}

--- a/web/src/catalog/pages/__tests__/FranchiseListPage.test.tsx
+++ b/web/src/catalog/pages/__tests__/FranchiseListPage.test.tsx
@@ -19,6 +19,7 @@ vi.mock('@tanstack/react-router', () => ({
       {children}
     </a>
   ),
+  useNavigate: () => vi.fn(),
 }));
 
 const mockUseFranchises = vi.fn();

--- a/web/src/catalog/pages/__tests__/ManufacturerListPage.test.tsx
+++ b/web/src/catalog/pages/__tests__/ManufacturerListPage.test.tsx
@@ -19,6 +19,7 @@ vi.mock('@tanstack/react-router', () => ({
       {children}
     </a>
   ),
+  useNavigate: () => vi.fn(),
 }));
 
 const mockUseManufacturers = vi.fn();

--- a/web/src/collection/components/AddToCollectionButton.tsx
+++ b/web/src/collection/components/AddToCollectionButton.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Check, Plus } from 'lucide-react';
+import { Plus } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { AddToCollectionDialog } from '@/collection/components/AddToCollectionDialog';
 import type { CollectionCheckEntry } from '@/lib/zod-schemas';
@@ -19,23 +19,15 @@ export function AddToCollectionButton({ item, checkResult, mutations }: AddToCol
 
   return (
     <>
-      <div className="flex items-center gap-3">
-        {alreadyOwned && (
-          <span className="text-xs text-amber-600 dark:text-amber-400 flex items-center gap-1">
-            <Check className="h-3 w-3" />
-            In collection ({count})
-          </span>
-        )}
-        <Button
-          variant="outline"
-          size="sm"
-          className="border-amber-300 text-amber-700 hover:bg-amber-50 dark:border-amber-700 dark:text-amber-400 dark:hover:bg-amber-950"
-          onClick={() => setDialogOpen(true)}
-        >
-          <Plus className="h-4 w-4 mr-1" />
-          {alreadyOwned ? 'Add Copy' : 'Add to Collection'}
-        </Button>
-      </div>
+      <Button
+        variant="outline"
+        size="sm"
+        className="border-amber-300 text-amber-700 hover:bg-amber-50 dark:border-amber-700 dark:text-amber-400 dark:hover:bg-amber-950"
+        onClick={() => setDialogOpen(true)}
+      >
+        <Plus className="h-4 w-4 mr-1" />
+        {alreadyOwned ? 'Add Copy' : 'Add to Collection'}
+      </Button>
 
       <AddToCollectionDialog
         open={dialogOpen}

--- a/web/src/collection/components/__tests__/AddToCollectionButton.test.tsx
+++ b/web/src/collection/components/__tests__/AddToCollectionButton.test.tsx
@@ -26,7 +26,7 @@ describe('AddToCollectionButton', () => {
     expect(screen.getByText('Add to Collection')).toBeInTheDocument();
   });
 
-  it('renders "In collection" indicator and "Add Copy" when owned', () => {
+  it('renders "Add Copy" when already owned', () => {
     render(
       <AddToCollectionButton
         item={{ id: 'i-1', name: 'Test' }}
@@ -34,7 +34,6 @@ describe('AddToCollectionButton', () => {
         mutations={mockMutations()}
       />
     );
-    expect(screen.getByText('In collection (2)')).toBeInTheDocument();
     expect(screen.getByText('Add Copy')).toBeInTheDocument();
   });
 

--- a/web/src/collection/pages/CollectionPage.tsx
+++ b/web/src/collection/pages/CollectionPage.tsx
@@ -32,7 +32,6 @@ export function CollectionPage() {
   const { runExport, isExporting } = useCollectionExport();
   const [editTarget, setEditTarget] = useState<CollectionItem | null>(null);
   const [importOpen, setImportOpen] = useState(false);
-  const [catalogItem, setCatalogItem] = useState<{ franchise: string; slug: string } | null>(null);
   const [view, setView] = useLocalStorage<CollectionViewMode>('trackem:collection-view', 'grid');
 
   const page = search.page ?? 1;
@@ -96,9 +95,27 @@ export function CollectionPage() {
     [navigate]
   );
 
-  const handleViewCatalog = useCallback((franchise: string, slug: string) => {
-    setCatalogItem({ franchise, slug });
-  }, []);
+  const handleViewCatalog = useCallback(
+    (franchise: string, slug: string) => {
+      void navigate({
+        to: '/collection',
+        search: (prev) => ({ ...prev, selected: slug, selected_franchise: franchise }),
+      });
+    },
+    [navigate]
+  );
+
+  const closeCatalogItem = useCallback(() => {
+    void navigate({
+      to: '/collection',
+      search: (prev) => {
+        const next = { ...prev };
+        delete (next as Record<string, unknown>).selected;
+        delete (next as Record<string, unknown>).selected_franchise;
+        return next;
+      },
+    });
+  }, [navigate]);
 
   const showEmptyState =
     !isPending && data && data.total_count === 0 && !search.franchise && !search.condition && !search.search;
@@ -221,9 +238,9 @@ export function CollectionPage() {
       />
 
       <ItemDetailSheet
-        franchise={catalogItem?.franchise ?? ''}
-        itemSlug={catalogItem?.slug}
-        onClose={() => setCatalogItem(null)}
+        franchise={search.selected_franchise ?? ''}
+        itemSlug={search.selected}
+        onClose={closeCatalogItem}
       />
     </div>
   );

--- a/web/src/routes/_authenticated/collection.tsx
+++ b/web/src/routes/_authenticated/collection.tsx
@@ -11,6 +11,8 @@ const collectionSearchSchema = z.object({
   search: z.string().optional().catch(undefined),
   page: z.coerce.number().int().min(1).optional().catch(undefined),
   limit: pageLimitSchema,
+  selected: z.string().optional().catch(undefined),
+  selected_franchise: z.string().optional().catch(undefined),
 });
 
 export const Route = createFileRoute('/_authenticated/collection')({


### PR DESCRIPTION
## Summary

- Redesign item and character detail sheets with 2-column CSS grids for property layout, tag chips in header for metadata, and collection status in header area
- Fix Radix DismissableLayer bug: non-modal sheets closed when list items received focus outside the dialog (e.g., `?sub_group=headmasters&selected=fangry`)
- Collection page item selection uses URL search params for shareable/bookmarkable links
- Franchise and manufacturer table rows fully clickable, matching item/character list behavior
- Appearances table: simplified year formatting, flush-left column alignment

## Test plan

- [x] 687 tests pass across 91 test files
- [x] Lint and typecheck clean
- [x] Sheet dismiss fix verified with Playwright
- [x] Page-level tests updated with `useNavigate` mock
- [x] Visual review in browser

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)