### PR TITLE
feat(api,db): collection item photos API + catalog contribution + GDPR

### DIFF
--- a/.claude/rules/api-database.md
+++ b/.claude/rules/api-database.md
@@ -71,6 +71,10 @@ paths:
 - `auth_events.user_id` uses `ON DELETE RESTRICT` (fixed in migration 030 from legacy SET NULL) — `user_id` is nullable (some events are pre-auth/system-generated), nullability is independent of the RESTRICT constraint
 - `deleteOrphanUser` only guards against `oauth_accounts` FK — RESTRICT on other tables causes the delete to fail if rows exist, but the caller's try/catch handles this gracefully
 - When adding a new table with a user FK, no special ON DELETE clause is needed (default RESTRICT is correct)
+- GDPR purge deletes `collection_item_photos` and `collection_items` rows (user data, not audit). `photo_contributions` rows are preserved as audit trail with `collection_item_photo_id` set to NULL via `ON DELETE SET NULL`. `item_photos.uploaded_by` is scrubbed to NULL (attribution removal).
+- GDPR purge of FORCE RLS tables requires a **context switch**: `gdprPurgeUser` calls `set_config('app.user_id', $targetUserId, true)` before DELETE statements on `collection_item_photos` and `collection_items`. Without this, the admin's RLS context would filter out the target user's rows. The context switch is safe because all subsequent operations in `gdprPurgeUser` and the caller touch only non-RLS tables.
+- `ON DELETE SET NULL` on `photo_contributions.collection_item_photo_id` is an intentional exception to the "NEVER ON DELETE SET NULL on user FKs" rule — this FK points to `collection_item_photos` (not `users`), and SET NULL is required so GDPR deletion of collection photos preserves contribution audit records.
+- GDPR file cleanup (`deleteUserPhotoDirectory`) runs after the transaction commits — best-effort, logged on failure. Orphaned files don't contain PII (photos of toys, not users).
 
 ## Collection API RLS Patterns
 

--- a/.claude/rules/api-routes.md
+++ b/.claude/rules/api-routes.md
@@ -203,3 +203,9 @@ Adding a column to item list API responses requires updating ALL of these (missi
 - Export/import: `GET /collection/export` returns slug-based JSON (no UUIDs), `POST /collection/import` resolves slugs via `batchGetItemIdsBySlugs` (UNNEST query), uses SAVEPOINT per insert for partial success
 - Partial-success inserts require `SAVEPOINT` / `ROLLBACK TO SAVEPOINT` per insert — PostgreSQL aborts the entire transaction on any error without savepoints. Always log the error before rolling back.
 - Export includes `deleted_count` in stats for UI to prompt about soft-deleted items
+- Collection photo routes live in `src/collection/photos/` — registered as a sub-plugin of `collectionRoutes` at `/:id/photos`. `@fastify/multipart` registered scoped to the photo plugin (same pattern as catalog photos)
+- Collection photo queries accept `client: PoolClient` (collection RLS pattern), unlike catalog photo queries which use `pool.query()` directly
+- `getCollectionItemRef(client, collectionItemId)` is the shared lookup function for all collection photo handlers — returns `{ id, item_id } | null`, verifies existence and ownership via RLS
+- Collection photos have no `status` column (private, no approval needed). Catalog photos contributed by users enter `item_photos` with `status: 'pending'` via `insertPendingCatalogPhoto`
+- `photo_contributions` table has no RLS (shared audit data). `collection_item_photo_id` is nullable with `ON DELETE SET NULL` for GDPR compatibility
+- Content-type hook in `collectionRoutes` accepts both `application/json` and `multipart/form-data` (updated from JSON-only when photo routes were added)

--- a/api/db/migrations/036_collection_item_photos.sql
+++ b/api/db/migrations/036_collection_item_photos.sql
@@ -1,0 +1,109 @@
+-- migrate:up
+-- ============================================================================
+-- Migration 036: Collection Item Photos + Photo Contributions
+--
+-- Two new tables for user-private collection photos and the optional
+-- "contribute to catalog" flow.
+--
+-- Design decisions:
+--   - collection_item_photos: RLS-protected (FORCE), user_id denormalized for
+--     efficient per-row policy evaluation
+--   - photo_contributions: NO RLS (shared audit data, like item_photos)
+--   - collection_item_photo_id is nullable with ON DELETE SET NULL so that
+--     GDPR deletion of collection photos preserves contribution audit records
+--   - item_photos.uploaded_by is already nullable (migration 011) — no ALTER
+-- ============================================================================
+
+-- ─── 1. collection_item_photos ───────────────────────────────────────────────
+
+CREATE TABLE public.collection_item_photos (
+    id                  UUID            PRIMARY KEY DEFAULT gen_random_uuid(),
+    collection_item_id  UUID            NOT NULL REFERENCES public.collection_items(id) ON DELETE RESTRICT,
+    user_id             UUID            NOT NULL REFERENCES public.users(id) ON DELETE RESTRICT,
+    url                 TEXT            NOT NULL,
+    caption             TEXT,
+    is_primary          BOOLEAN         NOT NULL DEFAULT false,
+    sort_order          INTEGER         NOT NULL DEFAULT 0,
+    dhash               TEXT            NOT NULL DEFAULT '',
+    created_at          TIMESTAMPTZ     NOT NULL DEFAULT now(),
+    updated_at          TIMESTAMPTZ     NOT NULL DEFAULT now()
+);
+
+CREATE TRIGGER collection_item_photos_updated_at
+    BEFORE UPDATE ON public.collection_item_photos
+    FOR EACH ROW EXECUTE FUNCTION public.update_updated_at();
+
+-- Primary access: list photos for a collection item, ordered
+CREATE INDEX idx_collection_item_photos_item
+    ON public.collection_item_photos (collection_item_id, sort_order ASC);
+
+-- Enforce at most one primary photo per collection item
+CREATE UNIQUE INDEX idx_collection_item_photos_one_primary
+    ON public.collection_item_photos (collection_item_id)
+    WHERE is_primary = true;
+
+-- ─── 2. Row Level Security ───────────────────────────────────────────────────
+
+ALTER TABLE public.collection_item_photos ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.collection_item_photos FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY collection_item_photos_select
+    ON public.collection_item_photos
+    FOR SELECT
+    USING (user_id = (SELECT current_app_user_id()));
+
+CREATE POLICY collection_item_photos_insert
+    ON public.collection_item_photos
+    FOR INSERT
+    WITH CHECK (user_id = (SELECT current_app_user_id()));
+
+CREATE POLICY collection_item_photos_update
+    ON public.collection_item_photos
+    FOR UPDATE
+    USING (user_id = (SELECT current_app_user_id()))
+    WITH CHECK (user_id = (SELECT current_app_user_id()));
+
+CREATE POLICY collection_item_photos_delete
+    ON public.collection_item_photos
+    FOR DELETE
+    USING (user_id = (SELECT current_app_user_id()));
+
+-- ─── 3. photo_contributions ──────────────────────────────────────────────────
+-- Audit trail for user photo contributions to the shared catalog.
+-- No RLS — shared application data (like item_photos).
+
+CREATE TABLE public.photo_contributions (
+    id                          UUID            PRIMARY KEY DEFAULT gen_random_uuid(),
+    collection_item_photo_id    UUID            REFERENCES public.collection_item_photos(id) ON DELETE SET NULL,
+    item_photo_id               UUID            REFERENCES public.item_photos(id) ON DELETE SET NULL,
+    contributed_by              UUID            NOT NULL REFERENCES public.users(id) ON DELETE RESTRICT,
+    item_id                     UUID            NOT NULL REFERENCES public.items(id) ON DELETE RESTRICT,
+    consent_version             TEXT            NOT NULL,
+    consent_granted_at          TIMESTAMPTZ     NOT NULL DEFAULT now(),
+    file_copied                 BOOLEAN         NOT NULL DEFAULT false,
+    status                      TEXT            NOT NULL DEFAULT 'pending'
+                                CHECK (status IN ('pending', 'approved', 'rejected', 'revoked')),
+    created_at                  TIMESTAMPTZ     NOT NULL DEFAULT now(),
+    updated_at                  TIMESTAMPTZ     NOT NULL DEFAULT now()
+);
+
+CREATE TRIGGER photo_contributions_updated_at
+    BEFORE UPDATE ON public.photo_contributions
+    FOR EACH ROW EXECUTE FUNCTION public.update_updated_at();
+
+-- Prevent double-contributing the same source photo (revoked contributions can be re-contributed)
+CREATE UNIQUE INDEX idx_photo_contributions_source
+    ON public.photo_contributions (collection_item_photo_id)
+    WHERE status != 'revoked' AND collection_item_photo_id IS NOT NULL;
+
+CREATE INDEX idx_photo_contributions_user
+    ON public.photo_contributions (contributed_by);
+
+CREATE INDEX idx_photo_contributions_item
+    ON public.photo_contributions (item_id, status);
+
+-- migrate:down
+DROP TRIGGER IF EXISTS photo_contributions_updated_at ON public.photo_contributions;
+DROP TABLE IF EXISTS public.photo_contributions;
+DROP TRIGGER IF EXISTS collection_item_photos_updated_at ON public.collection_item_photos;
+DROP TABLE IF EXISTS public.collection_item_photos;

--- a/api/db/schema.sql
+++ b/api/db/schema.sql
@@ -271,6 +271,26 @@ COMMENT ON COLUMN public.characters.continuity_family_id IS 'FK → continuity_f
 
 
 --
+-- Name: collection_item_photos; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.collection_item_photos (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    collection_item_id uuid NOT NULL,
+    user_id uuid NOT NULL,
+    url text NOT NULL,
+    caption text,
+    is_primary boolean DEFAULT false NOT NULL,
+    sort_order integer DEFAULT 0 NOT NULL,
+    dhash text DEFAULT ''::text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+ALTER TABLE ONLY public.collection_item_photos FORCE ROW LEVEL SECURITY;
+
+
+--
 -- Name: collection_items; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -588,6 +608,26 @@ CREATE TABLE public.oauth_accounts (
 
 
 --
+-- Name: photo_contributions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.photo_contributions (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    collection_item_photo_id uuid,
+    item_photo_id uuid,
+    contributed_by uuid NOT NULL,
+    item_id uuid NOT NULL,
+    consent_version text NOT NULL,
+    consent_granted_at timestamp with time zone DEFAULT now() NOT NULL,
+    file_copied boolean DEFAULT false NOT NULL,
+    status text DEFAULT 'pending'::text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT photo_contributions_status_check CHECK ((status = ANY (ARRAY['pending'::text, 'approved'::text, 'rejected'::text, 'revoked'::text])))
+);
+
+
+--
 -- Name: refresh_tokens; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -760,6 +800,14 @@ ALTER TABLE ONLY public.characters
 
 
 --
+-- Name: collection_item_photos collection_item_photos_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.collection_item_photos
+    ADD CONSTRAINT collection_item_photos_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: collection_items collection_items_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -893,6 +941,14 @@ ALTER TABLE ONLY public.ml_inference_events
 
 ALTER TABLE ONLY public.oauth_accounts
     ADD CONSTRAINT oauth_accounts_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: photo_contributions photo_contributions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.photo_contributions
+    ADD CONSTRAINT photo_contributions_pkey PRIMARY KEY (id);
 
 
 --
@@ -1089,6 +1145,20 @@ CREATE UNIQUE INDEX idx_characters_slug_franchise ON public.characters USING btr
 --
 
 CREATE INDEX idx_characters_type ON public.characters USING btree (character_type);
+
+
+--
+-- Name: idx_collection_item_photos_item; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_collection_item_photos_item ON public.collection_item_photos USING btree (collection_item_id, sort_order);
+
+
+--
+-- Name: idx_collection_item_photos_one_primary; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX idx_collection_item_photos_one_primary ON public.collection_item_photos USING btree (collection_item_id) WHERE (is_primary = true);
 
 
 --
@@ -1316,6 +1386,27 @@ CREATE INDEX idx_oauth_accounts_user_id ON public.oauth_accounts USING btree (us
 
 
 --
+-- Name: idx_photo_contributions_item; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_photo_contributions_item ON public.photo_contributions USING btree (item_id, status);
+
+
+--
+-- Name: idx_photo_contributions_source; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX idx_photo_contributions_source ON public.photo_contributions USING btree (collection_item_photo_id) WHERE ((status <> 'revoked'::text) AND (collection_item_photo_id IS NOT NULL));
+
+
+--
+-- Name: idx_photo_contributions_user; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_photo_contributions_user ON public.photo_contributions USING btree (contributed_by);
+
+
+--
 -- Name: idx_refresh_tokens_active; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -1407,6 +1498,13 @@ CREATE TRIGGER characters_updated_at BEFORE UPDATE ON public.characters FOR EACH
 
 
 --
+-- Name: collection_item_photos collection_item_photos_updated_at; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER collection_item_photos_updated_at BEFORE UPDATE ON public.collection_item_photos FOR EACH ROW EXECUTE FUNCTION public.update_updated_at();
+
+
+--
 -- Name: collection_items collection_items_updated_at; Type: TRIGGER; Schema: public; Owner: -
 --
 
@@ -1467,6 +1565,13 @@ CREATE TRIGGER items_updated_at BEFORE UPDATE ON public.items FOR EACH ROW EXECU
 --
 
 CREATE TRIGGER manufacturers_updated_at BEFORE UPDATE ON public.manufacturers FOR EACH ROW EXECUTE FUNCTION public.update_updated_at();
+
+
+--
+-- Name: photo_contributions photo_contributions_updated_at; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER photo_contributions_updated_at BEFORE UPDATE ON public.photo_contributions FOR EACH ROW EXECUTE FUNCTION public.update_updated_at();
 
 
 --
@@ -1584,6 +1689,22 @@ ALTER TABLE ONLY public.characters
 
 ALTER TABLE ONLY public.characters
     ADD CONSTRAINT characters_franchise_id_fkey FOREIGN KEY (franchise_id) REFERENCES public.franchises(id) ON DELETE RESTRICT;
+
+
+--
+-- Name: collection_item_photos collection_item_photos_collection_item_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.collection_item_photos
+    ADD CONSTRAINT collection_item_photos_collection_item_id_fkey FOREIGN KEY (collection_item_id) REFERENCES public.collection_items(id) ON DELETE RESTRICT;
+
+
+--
+-- Name: collection_item_photos collection_item_photos_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.collection_item_photos
+    ADD CONSTRAINT collection_item_photos_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE RESTRICT;
 
 
 --
@@ -1715,6 +1836,38 @@ ALTER TABLE ONLY public.oauth_accounts
 
 
 --
+-- Name: photo_contributions photo_contributions_collection_item_photo_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.photo_contributions
+    ADD CONSTRAINT photo_contributions_collection_item_photo_id_fkey FOREIGN KEY (collection_item_photo_id) REFERENCES public.collection_item_photos(id) ON DELETE SET NULL;
+
+
+--
+-- Name: photo_contributions photo_contributions_contributed_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.photo_contributions
+    ADD CONSTRAINT photo_contributions_contributed_by_fkey FOREIGN KEY (contributed_by) REFERENCES public.users(id) ON DELETE RESTRICT;
+
+
+--
+-- Name: photo_contributions photo_contributions_item_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.photo_contributions
+    ADD CONSTRAINT photo_contributions_item_id_fkey FOREIGN KEY (item_id) REFERENCES public.items(id) ON DELETE RESTRICT;
+
+
+--
+-- Name: photo_contributions photo_contributions_item_photo_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.photo_contributions
+    ADD CONSTRAINT photo_contributions_item_photo_id_fkey FOREIGN KEY (item_photo_id) REFERENCES public.item_photos(id) ON DELETE SET NULL;
+
+
+--
 -- Name: refresh_tokens refresh_tokens_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -1752,6 +1905,40 @@ ALTER TABLE ONLY public.toy_lines
 
 ALTER TABLE ONLY public.toy_lines
     ADD CONSTRAINT toy_lines_manufacturer_id_fkey FOREIGN KEY (manufacturer_id) REFERENCES public.manufacturers(id) ON DELETE RESTRICT;
+
+
+--
+-- Name: collection_item_photos; Type: ROW SECURITY; Schema: public; Owner: -
+--
+
+ALTER TABLE public.collection_item_photos ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: collection_item_photos collection_item_photos_delete; Type: POLICY; Schema: public; Owner: -
+--
+
+CREATE POLICY collection_item_photos_delete ON public.collection_item_photos FOR DELETE USING ((user_id = ( SELECT public.current_app_user_id() AS current_app_user_id)));
+
+
+--
+-- Name: collection_item_photos collection_item_photos_insert; Type: POLICY; Schema: public; Owner: -
+--
+
+CREATE POLICY collection_item_photos_insert ON public.collection_item_photos FOR INSERT WITH CHECK ((user_id = ( SELECT public.current_app_user_id() AS current_app_user_id)));
+
+
+--
+-- Name: collection_item_photos collection_item_photos_select; Type: POLICY; Schema: public; Owner: -
+--
+
+CREATE POLICY collection_item_photos_select ON public.collection_item_photos FOR SELECT USING ((user_id = ( SELECT public.current_app_user_id() AS current_app_user_id)));
+
+
+--
+-- Name: collection_item_photos collection_item_photos_update; Type: POLICY; Schema: public; Owner: -
+--
+
+CREATE POLICY collection_item_photos_update ON public.collection_item_photos FOR UPDATE USING ((user_id = ( SELECT public.current_app_user_id() AS current_app_user_id))) WITH CHECK ((user_id = ( SELECT public.current_app_user_id() AS current_app_user_id)));
 
 
 --
@@ -1834,4 +2021,5 @@ INSERT INTO public.schema_migrations (version) VALUES
     ('032'),
     ('033'),
     ('034'),
-    ('035');
+    ('035'),
+    ('036');

--- a/api/src/admin/queries.ts
+++ b/api/src/admin/queries.ts
@@ -154,6 +154,25 @@ export async function gdprPurgeUser(client: QueryOnlyClient, userId: string): Pr
     'UPDATE auth_events SET ip_address = NULL, user_agent = NULL, metadata = NULL WHERE user_id = $1',
     [userId]
   );
+
+  // 4. Delete collection photos and items (both tables have FORCE RLS).
+  //    Switch RLS context to the target user so DELETE can see their rows.
+  //    Subsequent operations touch non-RLS tables, so the context switch is safe.
+  await client.query("SELECT set_config('app.user_id', $1, true)", [userId]);
+
+  // 4a. Delete collection item photos first (FK child of collection_items).
+  //     ON DELETE SET NULL on photo_contributions.collection_item_photo_id
+  //     preserves contribution audit records with a NULL source reference.
+  await client.query('DELETE FROM collection_item_photos WHERE user_id = $1', [userId]);
+
+  // 4b. Delete collection items (FK parent, now safe after photo deletion)
+  await client.query('DELETE FROM collection_items WHERE user_id = $1', [userId]);
+
+  // 5. Scrub attribution on contributed catalog photos (item_photos has no RLS)
+  await client.query(
+    'UPDATE item_photos SET uploaded_by = NULL, updated_at = NOW() WHERE uploaded_by = $1',
+    [userId]
+  );
 }
 
 /**

--- a/api/src/admin/routes.test.ts
+++ b/api/src/admin/routes.test.ts
@@ -88,6 +88,10 @@ vi.mock('./queries.js', () => ({
   countActiveAdmins: vi.fn(),
 }));
 
+vi.mock('../collection/photos/storage.js', () => ({
+  deleteUserPhotoDirectory: vi.fn().mockResolvedValue(undefined),
+}));
+
 // ─── Import after mocks are registered ───────────────────────────────────────
 
 import { buildServer } from '../server.js';

--- a/api/src/admin/routes.ts
+++ b/api/src/admin/routes.ts
@@ -1,7 +1,9 @@
 import type { FastifyInstance } from 'fastify';
 import { withTransaction } from '../db/pool.js';
+import { config } from '../config.js';
 import * as queries from '../db/queries.js';
 import * as adminQueries from './queries.js';
+import { deleteUserPhotoDirectory } from '../collection/photos/storage.js';
 import {
   listUsersSchema,
   patchUserRoleSchema,
@@ -264,6 +266,14 @@ export async function adminRoutes(fastify: FastifyInstance, _opts: object): Prom
           fastify.log.error({ err: auditErr }, 'audit log failed for user_purged — purge will commit');
         }
       }, actor.sub);
+
+      // Best-effort file cleanup after transaction commits.
+      // Orphaned files are acceptable — they don't contain PII (photos of toys).
+      try {
+        await deleteUserPhotoDirectory(config.photos.storagePath, targetId);
+      } catch (err) {
+        fastify.log.error({ err, targetId }, 'Failed to delete user photo directory after GDPR purge');
+      }
 
       return reply.code(204).send();
     }

--- a/api/src/collection/photos/queries.ts
+++ b/api/src/collection/photos/queries.ts
@@ -1,0 +1,348 @@
+import type { PoolClient } from '../../db/pool.js';
+
+// ---------------------------------------------------------------------------
+// Row types
+// ---------------------------------------------------------------------------
+
+export interface CollectionPhotoRow {
+  id: string;
+  url: string;
+  caption: string | null;
+  is_primary: boolean;
+  sort_order: number;
+}
+
+export interface InsertCollectionPhotoParams {
+  id: string;
+  collectionItemId: string;
+  userId: string;
+  url: string;
+  sortOrder: number;
+  dhash: string;
+}
+
+export interface PhotoHashRow {
+  id: string;
+  url: string;
+  dhash: string;
+}
+
+export interface ContributionRow {
+  id: string;
+  collection_item_photo_id: string | null;
+  item_photo_id: string | null;
+  status: string;
+}
+
+const PHOTO_COLUMNS = 'id, url, caption, is_primary, sort_order';
+const DISPLAY_ORDER = 'is_primary DESC, sort_order ASC, created_at ASC';
+
+// ---------------------------------------------------------------------------
+// Collection item lookup (shared by all photo route handlers)
+// ---------------------------------------------------------------------------
+
+export interface CollectionItemRef {
+  id: string;
+  item_id: string;
+}
+
+/**
+ * Verify a collection item exists and is active. RLS enforces ownership.
+ * Returns the collection item ID and its linked catalog item ID.
+ *
+ * @param client - Transaction client with RLS context
+ * @param collectionItemId - Collection item UUID
+ */
+export async function getCollectionItemRef(
+  client: PoolClient,
+  collectionItemId: string
+): Promise<CollectionItemRef | null> {
+  const { rows } = await client.query<CollectionItemRef>(
+    'SELECT id, item_id FROM collection_items WHERE id = $1 AND deleted_at IS NULL',
+    [collectionItemId]
+  );
+  return rows[0] ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Catalog photo insert (for contribute handler)
+// ---------------------------------------------------------------------------
+
+/**
+ * Insert a pending catalog photo from a user contribution.
+ * Computes sort_order from the existing max for the catalog item.
+ * `item_photos` has no RLS — this works regardless of the app.user_id context.
+ *
+ * @param client - Transaction client
+ * @param params - Catalog photo insert parameters
+ */
+export async function insertPendingCatalogPhoto(
+  client: PoolClient,
+  params: {
+    id: string;
+    itemId: string;
+    url: string;
+    uploadedBy: string;
+    dhash: string;
+  }
+): Promise<void> {
+  await client.query(
+    `INSERT INTO item_photos (id, item_id, url, uploaded_by, sort_order, dhash, status)
+     VALUES ($1, $2, $3, $4, (SELECT COALESCE(MAX(sort_order), 0) + 1 FROM item_photos WHERE item_id = $2), $5, 'pending')`,
+    [params.id, params.itemId, params.url, params.uploadedBy, params.dhash]
+  );
+}
+
+// ---------------------------------------------------------------------------
+// CRUD
+// ---------------------------------------------------------------------------
+
+/**
+ * Insert a collection item photo.
+ *
+ * @param client - Transaction client with RLS context
+ * @param params - Photo insert parameters
+ */
+export async function insertCollectionPhoto(
+  client: PoolClient,
+  params: InsertCollectionPhotoParams
+): Promise<CollectionPhotoRow> {
+  const { rows } = await client.query<CollectionPhotoRow>(
+    `INSERT INTO collection_item_photos (id, collection_item_id, user_id, url, sort_order, dhash)
+     VALUES ($1, $2, $3, $4, $5, $6)
+     RETURNING ${PHOTO_COLUMNS}`,
+    [params.id, params.collectionItemId, params.userId, params.url, params.sortOrder, params.dhash]
+  );
+  return rows[0]!;
+}
+
+/**
+ * List photos for a collection item, ordered for display.
+ *
+ * @param client - Transaction client with RLS context
+ * @param collectionItemId - Collection item UUID
+ */
+export async function listCollectionPhotos(client: PoolClient, collectionItemId: string): Promise<CollectionPhotoRow[]> {
+  const { rows } = await client.query<CollectionPhotoRow>(
+    `SELECT ${PHOTO_COLUMNS} FROM collection_item_photos
+     WHERE collection_item_id = $1
+     ORDER BY ${DISPLAY_ORDER}`,
+    [collectionItemId]
+  );
+  return rows;
+}
+
+/**
+ * Fetch dHash values for all photos of a collection item.
+ * Used by the upload handler to check for perceptual duplicates.
+ *
+ * @param client - Transaction client with RLS context
+ * @param collectionItemId - Collection item UUID
+ */
+export async function getPhotoHashesByCollectionItem(
+  client: PoolClient,
+  collectionItemId: string
+): Promise<PhotoHashRow[]> {
+  const { rows } = await client.query<PhotoHashRow>(
+    `SELECT id, url, dhash FROM collection_item_photos
+     WHERE collection_item_id = $1 AND dhash != ''`,
+    [collectionItemId]
+  );
+  return rows;
+}
+
+/**
+ * Get the current maximum sort_order for a collection item's photos.
+ *
+ * @param client - Transaction client with RLS context
+ * @param collectionItemId - Collection item UUID
+ */
+export async function getMaxSortOrder(client: PoolClient, collectionItemId: string): Promise<number> {
+  const { rows } = await client.query<{ max: number | null }>(
+    'SELECT MAX(sort_order) AS max FROM collection_item_photos WHERE collection_item_id = $1',
+    [collectionItemId]
+  );
+  return rows[0]?.max ?? 0;
+}
+
+/**
+ * Delete a collection photo by ID and collection item ID.
+ *
+ * @param client - Transaction client with RLS context
+ * @param photoId - Photo UUID
+ * @param collectionItemId - Collection item UUID
+ */
+export async function deleteCollectionPhoto(
+  client: PoolClient,
+  photoId: string,
+  collectionItemId: string
+): Promise<boolean> {
+  const { rowCount } = await client.query(
+    'DELETE FROM collection_item_photos WHERE id = $1 AND collection_item_id = $2',
+    [photoId, collectionItemId]
+  );
+  return (rowCount ?? 0) > 0;
+}
+
+/**
+ * Atomically clear the existing primary photo and set a new one.
+ *
+ * @param client - Transaction client with RLS context (already in a transaction)
+ * @param photoId - Photo UUID to promote
+ * @param collectionItemId - Collection item UUID
+ */
+export async function setCollectionPhotoPrimary(
+  client: PoolClient,
+  photoId: string,
+  collectionItemId: string
+): Promise<CollectionPhotoRow | null> {
+  await client.query(
+    'UPDATE collection_item_photos SET is_primary = false WHERE collection_item_id = $1 AND is_primary = true',
+    [collectionItemId]
+  );
+  const { rows } = await client.query<CollectionPhotoRow>(
+    `UPDATE collection_item_photos SET is_primary = true, updated_at = now()
+     WHERE id = $1 AND collection_item_id = $2
+     RETURNING ${PHOTO_COLUMNS}`,
+    [photoId, collectionItemId]
+  );
+  return rows[0] ?? null;
+}
+
+/**
+ * Bulk-update sort_order for photos of a collection item, returning the reordered list.
+ *
+ * @param client - Transaction client with RLS context (already in a transaction)
+ * @param collectionItemId - Collection item UUID
+ * @param order - Array of photo ID + new sort_order pairs
+ */
+export async function reorderCollectionPhotos(
+  client: PoolClient,
+  collectionItemId: string,
+  order: Array<{ id: string; sort_order: number }>
+): Promise<CollectionPhotoRow[]> {
+  if (order.length > 0) {
+    const values = order.map((o, i) => `($${i * 2 + 1}::uuid, $${i * 2 + 2}::int)`).join(', ');
+    const params = order.flatMap((o) => [o.id, o.sort_order]);
+
+    await client.query(
+      `UPDATE collection_item_photos SET sort_order = v.sort_order, updated_at = now()
+       FROM (VALUES ${values}) AS v(id, sort_order)
+       WHERE collection_item_photos.id = v.id AND collection_item_photos.collection_item_id = $${params.length + 1}`,
+      [...params, collectionItemId]
+    );
+  }
+
+  const { rows } = await client.query<CollectionPhotoRow>(
+    `SELECT ${PHOTO_COLUMNS} FROM collection_item_photos
+     WHERE collection_item_id = $1
+     ORDER BY ${DISPLAY_ORDER}`,
+    [collectionItemId]
+  );
+  return rows;
+}
+
+// ---------------------------------------------------------------------------
+// Contribution
+// ---------------------------------------------------------------------------
+
+/**
+ * Get a photo by ID (for the contribute handler to verify it exists and fetch its dhash).
+ *
+ * @param client - Transaction client with RLS context
+ * @param photoId - Photo UUID
+ * @param collectionItemId - Collection item UUID
+ */
+export async function getCollectionPhotoById(
+  client: PoolClient,
+  photoId: string,
+  collectionItemId: string
+): Promise<{ id: string; url: string; dhash: string; collection_item_id: string } | null> {
+  const { rows } = await client.query<{ id: string; url: string; dhash: string; collection_item_id: string }>(
+    `SELECT id, url, dhash, collection_item_id FROM collection_item_photos
+     WHERE id = $1 AND collection_item_id = $2`,
+    [photoId, collectionItemId]
+  );
+  return rows[0] ?? null;
+}
+
+/**
+ * Check if an active (non-revoked) contribution exists for a collection photo.
+ *
+ * @param client - Transaction client (no RLS on photo_contributions)
+ * @param collectionItemPhotoId - Collection item photo UUID
+ */
+export async function getActiveContribution(
+  client: PoolClient,
+  collectionItemPhotoId: string
+): Promise<ContributionRow | null> {
+  const { rows } = await client.query<ContributionRow>(
+    `SELECT id, collection_item_photo_id, item_photo_id, status FROM photo_contributions
+     WHERE collection_item_photo_id = $1 AND status != 'revoked'`,
+    [collectionItemPhotoId]
+  );
+  return rows[0] ?? null;
+}
+
+/**
+ * Insert a photo contribution record.
+ *
+ * @param client - Transaction client
+ * @param params - Contribution parameters
+ */
+export async function insertContribution(
+  client: PoolClient,
+  params: {
+    collectionItemPhotoId: string;
+    contributedBy: string;
+    itemId: string;
+    consentVersion: string;
+  }
+): Promise<{ id: string }> {
+  const { rows } = await client.query<{ id: string }>(
+    `INSERT INTO photo_contributions (collection_item_photo_id, contributed_by, item_id, consent_version)
+     VALUES ($1, $2, $3, $4)
+     RETURNING id`,
+    [params.collectionItemPhotoId, params.contributedBy, params.itemId, params.consentVersion]
+  );
+  return rows[0]!;
+}
+
+/**
+ * Update a contribution with the catalog photo ID and mark file as copied.
+ *
+ * @param client - Transaction client
+ * @param contributionId - Contribution UUID
+ * @param itemPhotoId - Catalog item_photos UUID
+ */
+export async function updateContributionCopied(
+  client: PoolClient,
+  contributionId: string,
+  itemPhotoId: string
+): Promise<void> {
+  await client.query(
+    `UPDATE photo_contributions SET item_photo_id = $1, file_copied = true, updated_at = now()
+     WHERE id = $2`,
+    [itemPhotoId, contributionId]
+  );
+}
+
+/**
+ * Revoke a contribution by setting status to 'revoked'.
+ *
+ * @param client - Transaction client
+ * @param photoId - Collection item photo UUID
+ * @param contributedBy - User UUID (for ownership verification)
+ */
+export async function revokeContribution(
+  client: PoolClient,
+  photoId: string,
+  contributedBy: string
+): Promise<boolean> {
+  const { rowCount } = await client.query(
+    `UPDATE photo_contributions SET status = 'revoked', updated_at = now()
+     WHERE collection_item_photo_id = $1 AND contributed_by = $2 AND status != 'revoked'`,
+    [photoId, contributedBy]
+  );
+  return (rowCount ?? 0) > 0;
+}

--- a/api/src/collection/photos/routes.test.ts
+++ b/api/src/collection/photos/routes.test.ts
@@ -1,0 +1,668 @@
+/**
+ * Integration tests for collection photo routes.
+ *
+ * Strategy: build a real Fastify server via buildServer() and use
+ * fastify.inject() to exercise the full request/response pipeline.
+ *
+ * Uses the collection test pattern: inline config mock, named query mocks,
+ * withTransaction passthrough with _userId for RLS context.
+ */
+
+import { describe, it, expect, vi, beforeEach, beforeAll, afterAll } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import type { PoolClient } from '../../db/pool.js';
+
+// ─── Generate a real EC key pair before vi.mock() hoisting ───────────────────
+const { testPrivatePem, testPublicPem } = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports -- required inside vi.hoisted
+  const nodeCrypto = require('node:crypto') as typeof import('node:crypto');
+  const { privateKey, publicKey } = nodeCrypto.generateKeyPairSync('ec', {
+    namedCurve: 'prime256v1',
+  });
+  return {
+    testPrivatePem: privateKey.export({ type: 'pkcs8', format: 'pem' }) as string,
+    testPublicPem: publicKey.export({ type: 'spki', format: 'pem' }) as string,
+  };
+});
+
+// ─── Module mocks ────────────────────────────────────────────────────────────
+
+vi.mock('../../config.js', () => ({
+  config: {
+    port: 3000,
+    corsOrigin: '*',
+    trustProxy: false,
+    secureCookies: false,
+    cookieSecret: 'test-cookie-secret-32-bytes-long!!',
+    logLevel: 'silent',
+    nodeEnv: 'test',
+    database: { url: 'postgresql://test:test@localhost/test', poolMax: 2 },
+    jwt: {
+      privateKey: testPrivatePem,
+      publicKey: testPublicPem,
+      keyId: 'test-kid',
+      issuer: 'test',
+      audience: 'test',
+      accessTokenExpiry: '15m',
+    },
+    apple: { bundleId: 'com.test' },
+    google: { webClientId: 'test' },
+    photos: {
+      storagePath: '/tmp/trackem-test-photos',
+      baseUrl: 'http://localhost:3010/photos',
+      maxSizeMb: 10,
+    },
+    ml: {
+      exportPath: '/tmp/trackem-test-ml-export',
+    },
+  },
+}));
+
+vi.mock('../../db/pool.js', () => ({
+  pool: { query: vi.fn(), connect: vi.fn(), on: vi.fn(), end: vi.fn() },
+  withTransaction: vi.fn(),
+}));
+
+vi.mock('../../auth/key-store.js', () => ({
+  initKeyStore: vi.fn(),
+  getCurrentKid: vi.fn().mockReturnValue('test-kid'),
+  getPublicKeyPem: vi.fn().mockReturnValue(testPublicPem),
+}));
+
+// Mock Sharp to avoid real image processing
+vi.mock('sharp', () => {
+  const mockSharp = () => ({
+    clone: () => mockSharp(),
+    resize: () => mockSharp(),
+    webp: () => mockSharp(),
+    toBuffer: () => Promise.resolve(Buffer.from('fake-webp')),
+    metadata: () => Promise.resolve({ width: 1000, height: 800 }),
+  });
+  return { default: mockSharp };
+});
+
+// Mock fs operations
+vi.mock('node:fs/promises', () => ({
+  mkdir: vi.fn().mockResolvedValue(undefined),
+  writeFile: vi.fn().mockResolvedValue(undefined),
+  unlink: vi.fn().mockResolvedValue(undefined),
+  readFile: vi.fn().mockResolvedValue(Buffer.from('fake-file-data')),
+  rm: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Mock dhash module
+const mockComputeDHash = vi.fn();
+const mockHammingDistance = vi.fn();
+vi.mock('../../catalog/photos/dhash.js', () => ({
+  computeDHash: (...args: unknown[]) => mockComputeDHash(...args),
+  hammingDistance: (...args: unknown[]) => mockHammingDistance(...args),
+}));
+
+// Mock fs sync operations (used in server.ts startup validation)
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
+  return {
+    ...actual,
+    accessSync: vi.fn(),
+  };
+});
+
+// Mock parent collection queries (collection routes imports these)
+vi.mock('../queries.js', () => ({
+  listCollectionItems: vi.fn(),
+  getCollectionItemById: vi.fn(),
+  lockCollectionItem: vi.fn(),
+  itemExists: vi.fn(),
+  insertCollectionItem: vi.fn(),
+  getCollectionStats: vi.fn(),
+  exportCollectionItems: vi.fn(),
+  batchGetItemIdsBySlugs: vi.fn(),
+  softDeleteAllCollectionItems: vi.fn(),
+  checkCollectionItems: vi.fn(),
+  updateCollectionItem: vi.fn(),
+  softDeleteCollectionItem: vi.fn(),
+  restoreCollectionItem: vi.fn(),
+}));
+
+// Mock photo queries — named function mocks (collection pattern)
+vi.mock('./queries.js', () => ({
+  getCollectionItemRef: vi.fn(),
+  insertCollectionPhoto: vi.fn(),
+  listCollectionPhotos: vi.fn(),
+  getPhotoHashesByCollectionItem: vi.fn(),
+  getMaxSortOrder: vi.fn(),
+  deleteCollectionPhoto: vi.fn(),
+  setCollectionPhotoPrimary: vi.fn(),
+  reorderCollectionPhotos: vi.fn(),
+  getCollectionPhotoById: vi.fn(),
+  getActiveContribution: vi.fn(),
+  insertContribution: vi.fn(),
+  insertPendingCatalogPhoto: vi.fn(),
+  updateContributionCopied: vi.fn(),
+  revokeContribution: vi.fn(),
+}));
+
+// ─── Import after mocks ─────────────────────────────────────────────────────
+
+import { buildServer } from '../../server.js';
+import * as pool from '../../db/pool.js';
+import * as photoQueries from './queries.js';
+
+// ─── Fixture data ────────────────────────────────────────────────────────────
+
+const USER_A_UUID = 'a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1';
+const COLLECTION_ITEM_UUID = 'c3c3c3c3-c3c3-c3c3-c3c3-c3c3c3c3c3c3';
+const CATALOG_ITEM_UUID = 'd4d4d4d4-d4d4-d4d4-d4d4-d4d4d4d4d4d4';
+const PHOTO_UUID = 'e5e5e5e5-e5e5-e5e5-e5e5-e5e5e5e5e5e5';
+const CONTRIBUTION_UUID = 'f6f6f6f6-f6f6-f6f6-f6f6-f6f6f6f6f6f6';
+
+const mockPhotoRow = {
+  id: PHOTO_UUID,
+  url: `collection/${USER_A_UUID}/${COLLECTION_ITEM_UUID}/${PHOTO_UUID}-original.webp`,
+  caption: null,
+  is_primary: false,
+  sort_order: 1,
+};
+
+// ─── Test helpers ────────────────────────────────────────────────────────────
+
+const fakeQuery = vi.fn();
+const fakeClient = { query: fakeQuery } as pool.QueryOnlyClient;
+
+function mockTx() {
+  vi.mocked(pool.withTransaction).mockImplementation(async (fn, _userId) => fn(fakeClient as PoolClient));
+}
+
+function mockCollectionItemExists(found = true) {
+  vi.mocked(photoQueries.getCollectionItemRef).mockResolvedValue(
+    found ? { id: COLLECTION_ITEM_UUID, item_id: CATALOG_ITEM_UUID } : null
+  );
+}
+
+function buildMultipartBody(filename: string, mimetype: string, content: Buffer): { body: Buffer; boundary: string } {
+  const boundary = '----TestBoundary' + Date.now();
+  const parts = [
+    `--${boundary}\r\n`,
+    `Content-Disposition: form-data; name="file"; filename="${filename}"\r\n`,
+    `Content-Type: ${mimetype}\r\n\r\n`,
+  ];
+  const header = Buffer.from(parts.join(''));
+  const footer = Buffer.from(`\r\n--${boundary}--\r\n`);
+  return { body: Buffer.concat([header, content, footer]), boundary };
+}
+
+// ─── Test suite ──────────────────────────────────────────────────────────────
+
+let server: FastifyInstance;
+
+beforeAll(async () => {
+  server = await buildServer();
+  await server.ready();
+});
+
+afterAll(async () => {
+  await server.close();
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockComputeDHash.mockResolvedValue('abcdef0123456789');
+  mockHammingDistance.mockReturnValue(64); // above threshold — no duplicate
+});
+
+function userToken(sub: string = USER_A_UUID): string {
+  return server.jwt.sign({ sub, role: 'user' });
+}
+
+function authHeaders(sub?: string) {
+  return { authorization: `Bearer ${userToken(sub)}` };
+}
+
+const BASE_URL = `/collection/${COLLECTION_ITEM_UUID}/photos`;
+
+// ═══════════════════════════════════════════════════════════════════════════
+// POST /collection/:id/photos — Upload
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('POST /collection/:id/photos', () => {
+  const fakeImage = Buffer.from('fake-image-data');
+
+  it('should return 201 with uploaded photo', async () => {
+    mockTx();
+    mockCollectionItemExists();
+    vi.mocked(photoQueries.getPhotoHashesByCollectionItem).mockResolvedValue([]);
+    vi.mocked(photoQueries.getMaxSortOrder).mockResolvedValue(0);
+    vi.mocked(photoQueries.insertCollectionPhoto).mockResolvedValue(mockPhotoRow);
+
+    const { body, boundary } = buildMultipartBody('photo.jpg', 'image/jpeg', fakeImage);
+
+    const res = await server.inject({
+      method: 'POST',
+      url: BASE_URL,
+      headers: {
+        ...authHeaders(),
+        'content-type': `multipart/form-data; boundary=${boundary}`,
+      },
+      payload: body,
+    });
+
+    expect(res.statusCode).toBe(201);
+    const json = JSON.parse(res.payload) as { photos: unknown[] };
+    expect(json.photos).toHaveLength(1);
+  });
+
+  it('should return 401 without auth', async () => {
+    const { body, boundary } = buildMultipartBody('photo.jpg', 'image/jpeg', fakeImage);
+
+    const res = await server.inject({
+      method: 'POST',
+      url: BASE_URL,
+      headers: { 'content-type': `multipart/form-data; boundary=${boundary}` },
+      payload: body,
+    });
+
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('should return 404 for non-existent collection item', async () => {
+    mockTx();
+    mockCollectionItemExists(false);
+
+    const { body, boundary } = buildMultipartBody('photo.jpg', 'image/jpeg', fakeImage);
+
+    const res = await server.inject({
+      method: 'POST',
+      url: BASE_URL,
+      headers: {
+        ...authHeaders(),
+        'content-type': `multipart/form-data; boundary=${boundary}`,
+      },
+      payload: body,
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('should return 400 for unsupported mime type', async () => {
+    mockTx();
+    mockCollectionItemExists();
+    vi.mocked(photoQueries.getPhotoHashesByCollectionItem).mockResolvedValue([]);
+
+    const { body, boundary } = buildMultipartBody('doc.pdf', 'application/pdf', fakeImage);
+
+    const res = await server.inject({
+      method: 'POST',
+      url: BASE_URL,
+      headers: {
+        ...authHeaders(),
+        'content-type': `multipart/form-data; boundary=${boundary}`,
+      },
+      payload: body,
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('should return 409 for duplicate photo', async () => {
+    mockTx();
+    mockCollectionItemExists();
+    vi.mocked(photoQueries.getPhotoHashesByCollectionItem).mockResolvedValue([
+      { id: 'existing-id', url: 'existing-url', dhash: 'abcdef0123456789' },
+    ]);
+    mockHammingDistance.mockReturnValue(5); // below threshold — duplicate
+
+    const { body, boundary } = buildMultipartBody('photo.jpg', 'image/jpeg', fakeImage);
+
+    const res = await server.inject({
+      method: 'POST',
+      url: BASE_URL,
+      headers: {
+        ...authHeaders(),
+        'content-type': `multipart/form-data; boundary=${boundary}`,
+      },
+      payload: body,
+    });
+
+    expect(res.statusCode).toBe(409);
+    const json = JSON.parse(res.payload) as { error: string; matched: { id: string } };
+    expect(json.matched.id).toBe('existing-id');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// GET /collection/:id/photos — List
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('GET /collection/:id/photos', () => {
+  it('should return 200 with photos list', async () => {
+    mockTx();
+    mockCollectionItemExists();
+    vi.mocked(photoQueries.listCollectionPhotos).mockResolvedValue([mockPhotoRow]);
+
+    const res = await server.inject({
+      method: 'GET',
+      url: BASE_URL,
+      headers: authHeaders(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const json = JSON.parse(res.payload) as { photos: unknown[] };
+    expect(json.photos).toHaveLength(1);
+  });
+
+  it('should return 404 for non-existent collection item', async () => {
+    mockTx();
+    mockCollectionItemExists(false);
+
+    const res = await server.inject({
+      method: 'GET',
+      url: BASE_URL,
+      headers: authHeaders(),
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('should return 401 without auth', async () => {
+    const res = await server.inject({
+      method: 'GET',
+      url: BASE_URL,
+    });
+
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// DELETE /collection/:id/photos/:photoId — Delete
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('DELETE /collection/:id/photos/:photoId', () => {
+  it('should return 204 on successful delete', async () => {
+    mockTx();
+    mockCollectionItemExists();
+    vi.mocked(photoQueries.deleteCollectionPhoto).mockResolvedValue(true);
+
+    const res = await server.inject({
+      method: 'DELETE',
+      url: `${BASE_URL}/${PHOTO_UUID}`,
+      headers: authHeaders(),
+    });
+
+    expect(res.statusCode).toBe(204);
+  });
+
+  it('should return 404 for non-existent photo', async () => {
+    mockTx();
+    mockCollectionItemExists();
+    vi.mocked(photoQueries.deleteCollectionPhoto).mockResolvedValue(false);
+
+    const res = await server.inject({
+      method: 'DELETE',
+      url: `${BASE_URL}/${PHOTO_UUID}`,
+      headers: authHeaders(),
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('should return 404 for non-existent collection item', async () => {
+    mockTx();
+    mockCollectionItemExists(false);
+
+    const res = await server.inject({
+      method: 'DELETE',
+      url: `${BASE_URL}/${PHOTO_UUID}`,
+      headers: authHeaders(),
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// PATCH /collection/:id/photos/:photoId/primary — Set Primary
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('PATCH /collection/:id/photos/:photoId/primary', () => {
+  it('should return 200 with updated photo', async () => {
+    mockTx();
+    mockCollectionItemExists();
+    vi.mocked(photoQueries.setCollectionPhotoPrimary).mockResolvedValue({ ...mockPhotoRow, is_primary: true });
+
+    const res = await server.inject({
+      method: 'PATCH',
+      url: `${BASE_URL}/${PHOTO_UUID}/primary`,
+      headers: authHeaders(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const json = JSON.parse(res.payload) as { photo: { is_primary: boolean } };
+    expect(json.photo.is_primary).toBe(true);
+  });
+
+  it('should return 404 for non-existent photo', async () => {
+    mockTx();
+    mockCollectionItemExists();
+    vi.mocked(photoQueries.setCollectionPhotoPrimary).mockResolvedValue(null);
+
+    const res = await server.inject({
+      method: 'PATCH',
+      url: `${BASE_URL}/${PHOTO_UUID}/primary`,
+      headers: authHeaders(),
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('should return 409 on concurrent primary update', async () => {
+    mockTx();
+    mockCollectionItemExists();
+    vi.mocked(photoQueries.setCollectionPhotoPrimary).mockRejectedValue(
+      new Error('duplicate key value violates unique constraint "idx_collection_item_photos_one_primary"')
+    );
+
+    const res = await server.inject({
+      method: 'PATCH',
+      url: `${BASE_URL}/${PHOTO_UUID}/primary`,
+      headers: authHeaders(),
+    });
+
+    expect(res.statusCode).toBe(409);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// PATCH /collection/:id/photos/reorder — Reorder
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('PATCH /collection/:id/photos/reorder', () => {
+  it('should return 200 with reordered photos', async () => {
+    mockTx();
+    mockCollectionItemExists();
+    vi.mocked(photoQueries.reorderCollectionPhotos).mockResolvedValue([mockPhotoRow]);
+
+    const res = await server.inject({
+      method: 'PATCH',
+      url: `${BASE_URL}/reorder`,
+      headers: {
+        ...authHeaders(),
+        'content-type': 'application/json',
+      },
+      payload: {
+        photos: [{ id: PHOTO_UUID, sort_order: 0 }],
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const json = JSON.parse(res.payload) as { photos: unknown[] };
+    expect(json.photos).toHaveLength(1);
+  });
+
+  it('should return 404 for non-existent collection item', async () => {
+    mockTx();
+    mockCollectionItemExists(false);
+
+    const res = await server.inject({
+      method: 'PATCH',
+      url: `${BASE_URL}/reorder`,
+      headers: {
+        ...authHeaders(),
+        'content-type': 'application/json',
+      },
+      payload: {
+        photos: [{ id: PHOTO_UUID, sort_order: 0 }],
+      },
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// POST /collection/:id/photos/:photoId/contribute — Contribute
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('POST /collection/:id/photos/:photoId/contribute', () => {
+  it('should return 201 on successful contribution', async () => {
+    mockTx();
+    mockCollectionItemExists();
+    vi.mocked(photoQueries.getCollectionPhotoById).mockResolvedValue({
+      id: PHOTO_UUID,
+      url: mockPhotoRow.url,
+      dhash: 'abcdef0123456789',
+      collection_item_id: COLLECTION_ITEM_UUID,
+    });
+    vi.mocked(photoQueries.getActiveContribution).mockResolvedValue(null);
+    vi.mocked(photoQueries.insertContribution).mockResolvedValue({ id: CONTRIBUTION_UUID });
+    vi.mocked(photoQueries.insertPendingCatalogPhoto).mockResolvedValue(undefined);
+    vi.mocked(photoQueries.updateContributionCopied).mockResolvedValue(undefined);
+
+    const res = await server.inject({
+      method: 'POST',
+      url: `${BASE_URL}/${PHOTO_UUID}/contribute`,
+      headers: {
+        ...authHeaders(),
+        'content-type': 'application/json',
+      },
+      payload: {
+        consent_version: '1.0',
+        consent_acknowledged: true,
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const json = JSON.parse(res.payload) as { contribution_id: string };
+    expect(json.contribution_id).toBe(CONTRIBUTION_UUID);
+  });
+
+  it('should return 400 without consent', async () => {
+    const res = await server.inject({
+      method: 'POST',
+      url: `${BASE_URL}/${PHOTO_UUID}/contribute`,
+      headers: {
+        ...authHeaders(),
+        'content-type': 'application/json',
+      },
+      payload: {
+        consent_version: '1.0',
+        consent_acknowledged: false,
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('should return 409 for already-contributed photo', async () => {
+    mockTx();
+    mockCollectionItemExists();
+    vi.mocked(photoQueries.getCollectionPhotoById).mockResolvedValue({
+      id: PHOTO_UUID,
+      url: mockPhotoRow.url,
+      dhash: 'abcdef0123456789',
+      collection_item_id: COLLECTION_ITEM_UUID,
+    });
+    vi.mocked(photoQueries.getActiveContribution).mockResolvedValue({
+      id: CONTRIBUTION_UUID,
+      collection_item_photo_id: PHOTO_UUID,
+      item_photo_id: null,
+      status: 'pending',
+    });
+
+    const res = await server.inject({
+      method: 'POST',
+      url: `${BASE_URL}/${PHOTO_UUID}/contribute`,
+      headers: {
+        ...authHeaders(),
+        'content-type': 'application/json',
+      },
+      payload: {
+        consent_version: '1.0',
+        consent_acknowledged: true,
+      },
+    });
+
+    expect(res.statusCode).toBe(409);
+  });
+
+  it('should return 404 for non-existent photo', async () => {
+    mockTx();
+    mockCollectionItemExists();
+    vi.mocked(photoQueries.getCollectionPhotoById).mockResolvedValue(null);
+
+    const res = await server.inject({
+      method: 'POST',
+      url: `${BASE_URL}/${PHOTO_UUID}/contribute`,
+      headers: {
+        ...authHeaders(),
+        'content-type': 'application/json',
+      },
+      payload: {
+        consent_version: '1.0',
+        consent_acknowledged: true,
+      },
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// DELETE /collection/:id/photos/:photoId/contribution — Revoke
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('DELETE /collection/:id/photos/:photoId/contribution', () => {
+  it('should return 200 with revoked status', async () => {
+    mockTx();
+    vi.mocked(photoQueries.getCollectionPhotoById).mockResolvedValue({
+      id: PHOTO_UUID,
+      url: mockPhotoRow.url,
+      dhash: 'abcdef0123456789',
+      collection_item_id: COLLECTION_ITEM_UUID,
+    });
+    vi.mocked(photoQueries.revokeContribution).mockResolvedValue(true);
+
+    const res = await server.inject({
+      method: 'DELETE',
+      url: `${BASE_URL}/${PHOTO_UUID}/contribution`,
+      headers: authHeaders(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const json = JSON.parse(res.payload) as { revoked: boolean };
+    expect(json.revoked).toBe(true);
+  });
+
+  it('should return 404 for non-existent photo', async () => {
+    mockTx();
+    vi.mocked(photoQueries.getCollectionPhotoById).mockResolvedValue(null);
+
+    const res = await server.inject({
+      method: 'DELETE',
+      url: `${BASE_URL}/${PHOTO_UUID}/contribution`,
+      headers: authHeaders(),
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+});

--- a/api/src/collection/photos/routes.ts
+++ b/api/src/collection/photos/routes.ts
@@ -1,0 +1,372 @@
+import { randomUUID } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import type { FastifyInstance } from 'fastify';
+import multipart from '@fastify/multipart';
+import { config } from '../../config.js';
+import { withTransaction } from '../../db/pool.js';
+import { processUpload, DimensionError } from '../../catalog/photos/thumbnails.js';
+import { computeDHash, hammingDistance } from '../../catalog/photos/dhash.js';
+import {
+  photoDir as catalogPhotoDir,
+  photoPath as catalogPhotoPath,
+  photoRelativeUrl as catalogPhotoRelativeUrl,
+  ensureDir as ensureCatalogDir,
+  writePhoto as writeCatalogPhoto,
+  deletePhotoFiles as deleteCatalogPhotoFiles,
+} from '../../catalog/photos/storage.js';
+import * as photoQueries from './queries.js';
+import type { PhotoHashRow } from './queries.js';
+import {
+  collectionPhotoDir,
+  collectionPhotoPath,
+  collectionPhotoRelativeUrl,
+  ensureDir,
+  writePhoto,
+  deleteCollectionPhotoFiles,
+} from './storage.js';
+import {
+  uploadCollectionPhotosSchema,
+  listCollectionPhotosSchema,
+  deleteCollectionPhotoSchema,
+  setPrimaryCollectionPhotoSchema,
+  reorderCollectionPhotosSchema,
+  contributePhotoSchema,
+  revokeContributionSchema,
+} from './schemas.js';
+
+const ALLOWED_MIME_TYPES = new Set(['image/jpeg', 'image/png', 'image/webp', 'image/gif']);
+const MAX_FILES = 10;
+const DHASH_THRESHOLD = 10;
+
+const writeRateLimit = { rateLimit: { max: 20, timeWindow: '1 minute' } } as const;
+const mutationRateLimit = { rateLimit: { max: 30, timeWindow: '1 minute' } } as const;
+const readRateLimit = { rateLimit: { max: 60, timeWindow: '1 minute' } } as const;
+
+interface CollectionItemIdParams {
+  id: string;
+}
+
+interface CollectionPhotoIdParams extends CollectionItemIdParams {
+  photoId: string;
+}
+
+interface ContributeBody {
+  consent_version: string;
+  consent_acknowledged: boolean;
+}
+
+interface ReorderBody {
+  photos: Array<{ id: string; sort_order: number }>;
+}
+
+/**
+ * Register collection photo routes under /:id/photos.
+ *
+ * @param fastify - Fastify instance
+ * @param _opts - Plugin options (unused)
+ */
+export async function collectionPhotoRoutes(fastify: FastifyInstance, _opts: object): Promise<void> {
+  await fastify.register(multipart, {
+    limits: {
+      fileSize: config.photos.maxSizeMb * 1024 * 1024,
+      files: MAX_FILES,
+    },
+  });
+
+  const authPreHandler = [fastify.authenticate, fastify.requireRole('user')];
+
+  // ─── POST / — Upload photos ────────────────────────────────────────────
+
+  fastify.post<{ Params: CollectionItemIdParams }>(
+    '/',
+    { schema: uploadCollectionPhotosSchema, preHandler: authPreHandler, config: writeRateLimit },
+    async (request, reply) => {
+      const collectionItemId = request.params.id;
+      const userId = request.user.sub;
+
+      return withTransaction(async (client) => {
+        const itemRef = await photoQueries.getCollectionItemRef(client, collectionItemId);
+        if (!itemRef) return reply.code(404).send({ error: 'Collection item not found' });
+
+        const processed: Array<{
+          photoId: string;
+          dhash: string;
+          thumb: Buffer;
+          original: Buffer;
+        }> = [];
+
+        const existingHashes = await photoQueries.getPhotoHashesByCollectionItem(client, collectionItemId);
+        const batchHashes: PhotoHashRow[] = [];
+
+        const parts = request.parts();
+        for await (const part of parts) {
+          if (part.type !== 'file') continue;
+
+          if (!ALLOWED_MIME_TYPES.has(part.mimetype)) {
+            return reply.code(400).send({
+              error: `Unsupported image type: ${part.mimetype}. Allowed: JPEG, PNG, WebP, GIF`,
+            });
+          }
+
+          let inputBuffer: Buffer;
+          try {
+            inputBuffer = await part.toBuffer();
+          } catch {
+            return reply.code(413).send({ error: `File exceeds maximum size of ${config.photos.maxSizeMb}MB` });
+          }
+
+          let dhash: string;
+          let result;
+          try {
+            dhash = await computeDHash(inputBuffer);
+
+            const allHashes = [...existingHashes, ...batchHashes];
+            const match = allHashes.find((h) => hammingDistance(dhash, h.dhash) <= DHASH_THRESHOLD);
+            if (match) {
+              return reply.code(409).send({
+                error: 'Duplicate photo detected',
+                matched: { id: match.id, url: match.url },
+              });
+            }
+
+            result = await processUpload(inputBuffer);
+          } catch (err) {
+            if (err instanceof DimensionError) {
+              return reply.code(400).send({ error: err.message });
+            }
+            return reply.code(400).send({ error: 'Invalid image file' });
+          }
+
+          const photoId = randomUUID();
+          batchHashes.push({ id: photoId, url: collectionPhotoRelativeUrl(userId, collectionItemId, photoId), dhash });
+          processed.push({ photoId, dhash, ...result });
+        }
+
+        if (processed.length === 0) {
+          return reply.code(400).send({ error: 'No image files provided' });
+        }
+
+        const dir = collectionPhotoDir(config.photos.storagePath, userId, collectionItemId);
+        await ensureDir(dir);
+
+        for (const p of processed) {
+          const path = (size: 'thumb' | 'original') =>
+            collectionPhotoPath(config.photos.storagePath, userId, collectionItemId, p.photoId, size);
+          await Promise.all([writePhoto(path('thumb'), p.thumb), writePhoto(path('original'), p.original)]);
+        }
+
+        const maxSort = await photoQueries.getMaxSortOrder(client, collectionItemId);
+        const photos = [];
+
+        try {
+          for (let i = 0; i < processed.length; i++) {
+            const p = processed[i]!;
+            const row = await photoQueries.insertCollectionPhoto(client, {
+              id: p.photoId,
+              collectionItemId,
+              userId,
+              url: collectionPhotoRelativeUrl(userId, collectionItemId, p.photoId),
+              sortOrder: maxSort + i + 1,
+              dhash: p.dhash,
+            });
+            photos.push(row);
+          }
+        } catch (err) {
+          for (const p of processed) {
+            try {
+              await deleteCollectionPhotoFiles(config.photos.storagePath, userId, collectionItemId, p.photoId);
+            } catch {
+              /* best-effort cleanup */
+            }
+          }
+          throw err;
+        }
+
+        return reply.code(201).send({ photos });
+      }, userId);
+    }
+  );
+
+  // ─── GET / — List photos ───────────────────────────────────────────────
+
+  fastify.get<{ Params: CollectionItemIdParams }>(
+    '/',
+    { schema: listCollectionPhotosSchema, preHandler: authPreHandler, config: readRateLimit },
+    async (request, reply) => {
+      const collectionItemId = request.params.id;
+
+      return withTransaction(async (client) => {
+        const itemRef = await photoQueries.getCollectionItemRef(client, collectionItemId);
+        if (!itemRef) return reply.code(404).send({ error: 'Collection item not found' });
+
+        const photos = await photoQueries.listCollectionPhotos(client, collectionItemId);
+        return { photos };
+      }, request.user.sub);
+    }
+  );
+
+  // ─── PATCH /reorder — Reorder photos (must precede /:photoId) ──────────
+
+  fastify.patch<{ Params: CollectionItemIdParams; Body: ReorderBody }>(
+    '/reorder',
+    { schema: reorderCollectionPhotosSchema, preHandler: authPreHandler, config: mutationRateLimit },
+    async (request, reply) => {
+      const collectionItemId = request.params.id;
+
+      return withTransaction(async (client) => {
+        const itemRef = await photoQueries.getCollectionItemRef(client, collectionItemId);
+        if (!itemRef) return reply.code(404).send({ error: 'Collection item not found' });
+
+        const photos = await photoQueries.reorderCollectionPhotos(client, collectionItemId, request.body.photos);
+        return { photos };
+      }, request.user.sub);
+    }
+  );
+
+  // ─── DELETE /:photoId — Delete photo ───────────────────────────────────
+
+  fastify.delete<{ Params: CollectionPhotoIdParams }>(
+    '/:photoId',
+    { schema: deleteCollectionPhotoSchema, preHandler: authPreHandler, config: mutationRateLimit },
+    async (request, reply) => {
+      const { id: collectionItemId, photoId } = request.params;
+      const userId = request.user.sub;
+
+      return withTransaction(async (client) => {
+        const itemRef = await photoQueries.getCollectionItemRef(client, collectionItemId);
+        if (!itemRef) return reply.code(404).send({ error: 'Collection item not found' });
+
+        const deleted = await photoQueries.deleteCollectionPhoto(client, photoId, collectionItemId);
+        if (!deleted) return reply.code(404).send({ error: 'Photo not found' });
+
+        try {
+          await deleteCollectionPhotoFiles(config.photos.storagePath, userId, collectionItemId, photoId);
+        } catch (err) {
+          request.log.error(
+            { err, collectionItemId, photoId },
+            'Failed to delete collection photo files after DB delete — files may be orphaned'
+          );
+        }
+
+        return reply.code(204).send();
+      }, userId);
+    }
+  );
+
+  // ─── PATCH /:photoId/primary — Set primary photo ───────────────────────
+
+  fastify.patch<{ Params: CollectionPhotoIdParams }>(
+    '/:photoId/primary',
+    { schema: setPrimaryCollectionPhotoSchema, preHandler: authPreHandler, config: mutationRateLimit },
+    async (request, reply) => {
+      const { id: collectionItemId, photoId } = request.params;
+
+      return withTransaction(async (client) => {
+        const itemRef = await photoQueries.getCollectionItemRef(client, collectionItemId);
+        if (!itemRef) return reply.code(404).send({ error: 'Collection item not found' });
+
+        let photo;
+        try {
+          photo = await photoQueries.setCollectionPhotoPrimary(client, photoId, collectionItemId);
+        } catch (err) {
+          if (err instanceof Error && err.message.includes('idx_collection_item_photos_one_primary')) {
+            return reply.code(409).send({ error: 'Concurrent primary photo update. Please retry.' });
+          }
+          throw err;
+        }
+
+        if (!photo) return reply.code(404).send({ error: 'Photo not found' });
+        return { photo };
+      }, request.user.sub);
+    }
+  );
+
+  // ─── POST /:photoId/contribute — Contribute to catalog ─────────────────
+
+  fastify.post<{ Params: CollectionPhotoIdParams; Body: ContributeBody }>(
+    '/:photoId/contribute',
+    { schema: contributePhotoSchema, preHandler: authPreHandler, config: writeRateLimit },
+    async (request, reply) => {
+      const { id: collectionItemId, photoId } = request.params;
+      const { consent_version, consent_acknowledged } = request.body;
+      const userId = request.user.sub;
+
+      if (!consent_acknowledged) {
+        return reply.code(400).send({ error: 'Consent must be acknowledged' });
+      }
+
+      return withTransaction(async (client) => {
+        const itemRef = await photoQueries.getCollectionItemRef(client, collectionItemId);
+        if (!itemRef) return reply.code(404).send({ error: 'Collection item not found' });
+        const catalogItemId = itemRef.item_id;
+
+        const photo = await photoQueries.getCollectionPhotoById(client, photoId, collectionItemId);
+        if (!photo) return reply.code(404).send({ error: 'Photo not found' });
+
+        const existing = await photoQueries.getActiveContribution(client, photoId);
+        if (existing) {
+          return reply.code(409).send({ error: 'This photo has already been contributed' });
+        }
+
+        const contribution = await photoQueries.insertContribution(client, {
+          collectionItemPhotoId: photoId,
+          contributedBy: userId,
+          itemId: catalogItemId,
+          consentVersion: consent_version,
+        });
+
+        const newPhotoId = randomUUID();
+        const catalogDir = catalogPhotoDir(config.photos.storagePath, catalogItemId);
+        await ensureCatalogDir(catalogDir);
+
+        try {
+          for (const size of ['thumb', 'original'] as const) {
+            const srcPath = collectionPhotoPath(config.photos.storagePath, userId, collectionItemId, photoId, size);
+            const destPath = catalogPhotoPath(config.photos.storagePath, catalogItemId, newPhotoId, size);
+            const data = await readFile(srcPath);
+            await writeCatalogPhoto(destPath, data);
+          }
+        } catch (err) {
+          try {
+            await deleteCatalogPhotoFiles(config.photos.storagePath, catalogItemId, newPhotoId);
+          } catch {
+            /* best-effort */
+          }
+          throw err;
+        }
+
+        const catalogUrl = catalogPhotoRelativeUrl(catalogItemId, newPhotoId);
+        await photoQueries.insertPendingCatalogPhoto(client, {
+          id: newPhotoId,
+          itemId: catalogItemId,
+          url: catalogUrl,
+          uploadedBy: userId,
+          dhash: photo.dhash,
+        });
+
+        await photoQueries.updateContributionCopied(client, contribution.id, newPhotoId);
+
+        return reply.code(201).send({ contribution_id: contribution.id });
+      }, userId);
+    }
+  );
+
+  // ─── DELETE /:photoId/contribution — Revoke contribution ───────────────
+
+  fastify.delete<{ Params: CollectionPhotoIdParams }>(
+    '/:photoId/contribution',
+    { schema: revokeContributionSchema, preHandler: authPreHandler, config: mutationRateLimit },
+    async (request, reply) => {
+      const { id: collectionItemId, photoId } = request.params;
+      const userId = request.user.sub;
+
+      return withTransaction(async (client) => {
+        const photo = await photoQueries.getCollectionPhotoById(client, photoId, collectionItemId);
+        if (!photo) return reply.code(404).send({ error: 'Photo not found' });
+
+        const revoked = await photoQueries.revokeContribution(client, photoId, userId);
+        return { revoked };
+      }, userId);
+    }
+  );
+}

--- a/api/src/collection/photos/schemas.ts
+++ b/api/src/collection/photos/schemas.ts
@@ -1,0 +1,232 @@
+import { errorResponse } from '../../catalog/shared/schemas.js';
+
+// ---------------------------------------------------------------------------
+// Params schemas
+// ---------------------------------------------------------------------------
+
+const collectionItemIdParams = {
+  type: 'object',
+  required: ['id'],
+  additionalProperties: false,
+  properties: {
+    id: { type: 'string', format: 'uuid' },
+  },
+} as const;
+
+const collectionPhotoIdParams = {
+  type: 'object',
+  required: ['id', 'photoId'],
+  additionalProperties: false,
+  properties: {
+    id: { type: 'string', format: 'uuid' },
+    photoId: { type: 'string', format: 'uuid' },
+  },
+} as const;
+
+// ---------------------------------------------------------------------------
+// Response schemas
+// ---------------------------------------------------------------------------
+
+/** Collection photo — no status field (private photos, no approval). */
+const collectionPhotoItem = {
+  type: 'object',
+  required: ['id', 'url', 'caption', 'is_primary', 'sort_order'],
+  additionalProperties: false,
+  properties: {
+    id: { type: 'string' },
+    url: { type: 'string' },
+    caption: { type: ['string', 'null'] },
+    is_primary: { type: 'boolean' },
+    sort_order: { type: 'integer' },
+  },
+} as const;
+
+const duplicatePhotoError = {
+  type: 'object',
+  required: ['error', 'matched'],
+  additionalProperties: false,
+  properties: {
+    error: { type: 'string' },
+    matched: {
+      type: 'object',
+      required: ['id', 'url'],
+      additionalProperties: false,
+      properties: {
+        id: { type: 'string' },
+        url: { type: 'string' },
+      },
+    },
+  },
+} as const;
+
+const contributeResponse = {
+  type: 'object',
+  required: ['contribution_id'],
+  additionalProperties: false,
+  properties: {
+    contribution_id: { type: 'string' },
+  },
+} as const;
+
+// ---------------------------------------------------------------------------
+// Route schemas
+// ---------------------------------------------------------------------------
+
+export const uploadCollectionPhotosSchema = {
+  description: 'Upload photos to a collection item.',
+  tags: ['collection-photos'],
+  summary: 'Upload collection photos',
+  params: collectionItemIdParams,
+  consumes: ['multipart/form-data'],
+  response: {
+    201: {
+      type: 'object',
+      required: ['photos'],
+      additionalProperties: false,
+      properties: {
+        photos: { type: 'array', items: collectionPhotoItem },
+      },
+    },
+    400: errorResponse,
+    401: errorResponse,
+    404: errorResponse,
+    409: duplicatePhotoError,
+    413: errorResponse,
+    500: errorResponse,
+  },
+} as const;
+
+export const listCollectionPhotosSchema = {
+  description: 'List photos for a collection item.',
+  tags: ['collection-photos'],
+  summary: 'List collection photos',
+  params: collectionItemIdParams,
+  response: {
+    200: {
+      type: 'object',
+      required: ['photos'],
+      additionalProperties: false,
+      properties: {
+        photos: { type: 'array', items: collectionPhotoItem },
+      },
+    },
+    401: errorResponse,
+    404: errorResponse,
+    500: errorResponse,
+  },
+} as const;
+
+export const deleteCollectionPhotoSchema = {
+  description: 'Delete a photo from a collection item.',
+  tags: ['collection-photos'],
+  summary: 'Delete collection photo',
+  params: collectionPhotoIdParams,
+  response: {
+    204: { type: 'null', description: 'Photo deleted' },
+    401: errorResponse,
+    404: errorResponse,
+    500: errorResponse,
+  },
+} as const;
+
+export const setPrimaryCollectionPhotoSchema = {
+  description: 'Set a photo as the primary photo for a collection item.',
+  tags: ['collection-photos'],
+  summary: 'Set primary collection photo',
+  params: collectionPhotoIdParams,
+  response: {
+    200: {
+      type: 'object',
+      required: ['photo'],
+      additionalProperties: false,
+      properties: { photo: collectionPhotoItem },
+    },
+    401: errorResponse,
+    404: errorResponse,
+    409: errorResponse,
+    500: errorResponse,
+  },
+} as const;
+
+export const reorderCollectionPhotosSchema = {
+  description: 'Reorder photos for a collection item.',
+  tags: ['collection-photos'],
+  summary: 'Reorder collection photos',
+  params: collectionItemIdParams,
+  body: {
+    type: 'object',
+    required: ['photos'],
+    additionalProperties: false,
+    properties: {
+      photos: {
+        type: 'array',
+        minItems: 1,
+        maxItems: 100,
+        items: {
+          type: 'object',
+          required: ['id', 'sort_order'],
+          additionalProperties: false,
+          properties: {
+            id: { type: 'string', format: 'uuid' },
+            sort_order: { type: 'integer', minimum: 0 },
+          },
+        },
+      },
+    },
+  },
+  response: {
+    200: {
+      type: 'object',
+      required: ['photos'],
+      additionalProperties: false,
+      properties: {
+        photos: { type: 'array', items: collectionPhotoItem },
+      },
+    },
+    401: errorResponse,
+    404: errorResponse,
+    500: errorResponse,
+  },
+} as const;
+
+export const contributePhotoSchema = {
+  description: 'Contribute a collection photo to the shared catalog.',
+  tags: ['collection-photos'],
+  summary: 'Contribute photo to catalog',
+  params: collectionPhotoIdParams,
+  body: {
+    type: 'object',
+    required: ['consent_version', 'consent_acknowledged'],
+    additionalProperties: false,
+    properties: {
+      consent_version: { type: 'string', minLength: 1 },
+      consent_acknowledged: { type: 'boolean' },
+    },
+  },
+  response: {
+    201: contributeResponse,
+    400: errorResponse,
+    401: errorResponse,
+    404: errorResponse,
+    409: errorResponse,
+    500: errorResponse,
+  },
+} as const;
+
+export const revokeContributionSchema = {
+  description: 'Revoke a photo contribution.',
+  tags: ['collection-photos'],
+  summary: 'Revoke contribution',
+  params: collectionPhotoIdParams,
+  response: {
+    200: {
+      type: 'object',
+      required: ['revoked'],
+      additionalProperties: false,
+      properties: { revoked: { type: 'boolean' } },
+    },
+    401: errorResponse,
+    404: errorResponse,
+    500: errorResponse,
+  },
+} as const;

--- a/api/src/collection/photos/storage.ts
+++ b/api/src/collection/photos/storage.ts
@@ -1,0 +1,89 @@
+import { rm, unlink } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { ensureDir, writePhoto } from '../../catalog/photos/storage.js';
+
+export { ensureDir, writePhoto };
+
+const SIZES = ['thumb', 'original'] as const;
+export type PhotoSize = (typeof SIZES)[number];
+
+/**
+ * Build the directory path for a collection item's photos.
+ *
+ * Layout: PHOTO_STORAGE_PATH/collection/{userId}/{collectionItemId}/
+ *
+ * @param storagePath - Root photo storage directory
+ * @param userId - User UUID
+ * @param collectionItemId - Collection item UUID
+ */
+export function collectionPhotoDir(storagePath: string, userId: string, collectionItemId: string): string {
+  return join(storagePath, 'collection', userId, collectionItemId);
+}
+
+/**
+ * Build the full file path for a specific photo size variant.
+ *
+ * @param storagePath - Root photo storage directory
+ * @param userId - User UUID
+ * @param collectionItemId - Collection item UUID
+ * @param photoId - Photo UUID
+ * @param size - Photo size variant (thumb, original)
+ */
+export function collectionPhotoPath(
+  storagePath: string,
+  userId: string,
+  collectionItemId: string,
+  photoId: string,
+  size: PhotoSize
+): string {
+  return join(storagePath, 'collection', userId, collectionItemId, `${photoId}-${size}.webp`);
+}
+
+/**
+ * Build the relative URL stored in the database (original size).
+ *
+ * @param userId - User UUID
+ * @param collectionItemId - Collection item UUID
+ * @param photoId - Photo UUID
+ */
+export function collectionPhotoRelativeUrl(userId: string, collectionItemId: string, photoId: string): string {
+  return `collection/${userId}/${collectionItemId}/${photoId}-original.webp`;
+}
+
+/**
+ * Delete all size variants for a collection photo. Swallows ENOENT (idempotent).
+ *
+ * @param storagePath - Root photo storage directory
+ * @param userId - User UUID
+ * @param collectionItemId - Collection item UUID
+ * @param photoId - Photo UUID
+ */
+export async function deleteCollectionPhotoFiles(
+  storagePath: string,
+  userId: string,
+  collectionItemId: string,
+  photoId: string
+): Promise<void> {
+  for (const size of SIZES) {
+    const filePath = collectionPhotoPath(storagePath, userId, collectionItemId, photoId, size);
+    try {
+      await unlink(filePath);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+    }
+  }
+}
+
+/**
+ * Recursively delete a user's entire collection photo directory.
+ * Used during GDPR purge after the DB transaction commits.
+ * Swallows ENOENT (directory may not exist if user never uploaded photos).
+ *
+ * @param storagePath - Root photo storage directory
+ * @param userId - User UUID
+ */
+export async function deleteUserPhotoDirectory(storagePath: string, userId: string): Promise<void> {
+  const dirPath = join(storagePath, 'collection', userId);
+  await rm(dirPath, { recursive: true, force: true });
+}

--- a/api/src/collection/routes.test.ts
+++ b/api/src/collection/routes.test.ts
@@ -87,6 +87,11 @@ vi.mock('./queries.js', () => ({
   restoreCollectionItem: vi.fn(),
 }));
 
+// Mock the photo sub-plugin to avoid multipart/sharp/fs dependencies in collection tests
+vi.mock('./photos/routes.js', () => ({
+  collectionPhotoRoutes: vi.fn().mockImplementation(async () => {}),
+}));
+
 // ─── Import after mocks ─────────────────────────────────────────────────────
 
 import { buildServer } from '../server.js';

--- a/api/src/collection/routes.ts
+++ b/api/src/collection/routes.ts
@@ -5,6 +5,7 @@ import { withTransaction } from '../db/pool.js';
 import type { PackageCondition } from '../types/index.js';
 import type { CollectionListRow } from './queries.js';
 import * as queries from './queries.js';
+import { collectionPhotoRoutes } from './photos/routes.js';
 import {
   addCollectionItemSchema,
   checkCollectionSchema,
@@ -156,18 +157,21 @@ const importRateLimit = { rateLimit: { max: 20, timeWindow: '1 minute' } } as co
  * @param fastify - Fastify instance
  * @param _opts - Plugin options (unused)
  */
-// eslint-disable-next-line @typescript-eslint/require-await -- Fastify plugin contract requires async
 export async function collectionRoutes(fastify: FastifyInstance, _opts: object): Promise<void> {
   // ─── Content-Type enforcement ─────────────────────────────────────────
+  // Accept application/json for standard routes and multipart/form-data for photo uploads
   fastify.addHook('preValidation', async (request, reply) => {
     if (request.method !== 'POST' && request.method !== 'PATCH') return;
     const contentType = request.headers['content-type'];
     if (contentType === undefined) return;
     const baseType = (contentType.split(';')[0] ?? '').trim();
-    if (baseType !== 'application/json') {
-      return reply.code(415).send({ error: 'Content-Type must be application/json' });
+    if (baseType !== 'application/json' && !baseType.startsWith('multipart/form-data')) {
+      return reply.code(415).send({ error: 'Content-Type must be application/json or multipart/form-data' });
     }
   });
+
+  // ─── Photo sub-plugin (must precede /:id routes) ──────────────────────
+  await fastify.register(collectionPhotoRoutes, { prefix: '/:id/photos' });
 
   // requireRole('user') accepts all authenticated users (user, curator, admin)
   // per the role hierarchy. The real access control is RLS on collection_items.

--- a/changelog/2026-04-03T040312Z_collection-item-photos-slice1.md
+++ b/changelog/2026-04-03T040312Z_collection-item-photos-slice1.md
@@ -1,0 +1,126 @@
+# Collection Item Photos — DB + API Routes (Slice 1)
+
+**Date:** 2026-04-03
+**Time:** 04:03:12 UTC
+**Type:** Feature
+**Phase:** 1.6
+**Version:** v0.14.0
+
+## Summary
+
+Implemented the backend foundation for user collection item photos and the catalog contribution flow. Users can upload private photos to their collection items, and optionally contribute them to the shared catalog (pending curator approval). GDPR purge extended to delete collection data and anonymize contributed catalog photos.
+
+---
+
+## Changes Implemented
+
+### 1. Database Migration (036)
+
+Two new tables:
+
+- **`collection_item_photos`** — RLS-protected (FORCE), stores user-private photos per collection item. Denormalized `user_id` for efficient RLS policy evaluation. Perceptual hash (`dhash`) for duplicate detection.
+- **`photo_contributions`** — No RLS (shared audit data). Tracks consent version, contribution status, and links between collection photos and catalog copies. `collection_item_photo_id` is nullable with `ON DELETE SET NULL` for GDPR compatibility.
+
+### 2. API Routes (7 endpoints)
+
+All under `/collection/:id/photos`, using `withTransaction` with RLS context:
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| POST | `/` | Upload photos (multipart, max 10) |
+| GET | `/` | List photos |
+| PATCH | `/reorder` | Reorder photos |
+| PATCH | `/:photoId/primary` | Set primary |
+| DELETE | `/:photoId` | Delete photo |
+| POST | `/:photoId/contribute` | Contribute to catalog |
+| DELETE | `/:photoId/contribution` | Revoke contribution |
+
+### 3. GDPR Extension
+
+Extended `gdprPurgeUser()` with RLS context switch pattern:
+- Switches `app.user_id` to target user for FORCE RLS table access
+- Deletes `collection_item_photos` (ON DELETE SET NULL preserves audit)
+- Deletes `collection_items`
+- Scrubs `item_photos.uploaded_by` to NULL
+- Best-effort file cleanup after transaction commit
+
+### 4. Shared Query Functions
+
+- `getCollectionItemRef()` — shared collection item lookup for all photo handlers
+- `insertPendingCatalogPhoto()` — catalog photo insert in query layer (not inline SQL)
+
+**Created:**
+
+- `api/db/migrations/036_collection_item_photos.sql`
+- `api/src/collection/photos/routes.ts`
+- `api/src/collection/photos/queries.ts`
+- `api/src/collection/photos/schemas.ts`
+- `api/src/collection/photos/storage.ts`
+- `api/src/collection/photos/routes.test.ts`
+
+**Modified:**
+
+- `api/src/collection/routes.ts` — photo sub-plugin registration, content-type hook update
+- `api/src/admin/queries.ts` — GDPR purge extension
+- `api/src/admin/routes.ts` — file cleanup after GDPR
+- `api/src/collection/routes.test.ts` — mock for photo sub-plugin
+- `api/src/admin/routes.test.ts` — mock for `deleteUserPhotoDirectory`
+- `.claude/rules/api-database.md` — GDPR RLS context switch pattern
+- `.claude/rules/api-routes.md` — collection photo conventions
+
+---
+
+## Technical Details
+
+### RLS Context Switch for GDPR
+
+`gdprPurgeUser()` calls `set_config('app.user_id', $targetUserId, true)` before DELETE statements on FORCE RLS tables. This switches from the admin's context to the target user's, allowing the DELETE to see the target user's rows. Safe because subsequent operations touch only non-RLS tables.
+
+### Storage Layout
+
+Collection photos stored under `PHOTO_STORAGE_PATH/collection/{userId}/{collectionItemId}/{photoId}-{size}.webp`. Catalog contributions are file-copied (not linked) to `{itemId}/{newPhotoId}-{size}.webp`.
+
+### Contribution Flow
+
+1. Verify ownership via RLS
+2. Insert `photo_contributions` row
+3. Copy files to catalog directory
+4. Insert `item_photos` with `status: 'pending'`
+5. Update contribution with catalog photo ID
+
+---
+
+## Validation & Testing
+
+- 22 new integration tests (all passing)
+- 831 total tests passing, 0 lint errors
+- TypeScript build clean
+
+---
+
+## Impact Assessment
+
+- First feature to combine RLS-protected data with shared catalog data
+- Establishes the GDPR RLS context switch pattern for future FORCE RLS tables
+- No breaking changes to existing APIs
+
+---
+
+## Summary Statistics
+
+- 6 new files, 7 modified files
+- 22 new tests
+- 2 new database tables, 1 migration
+- 7 new API endpoints
+
+---
+
+## Next Steps
+
+- Slice 2 (#138): Web UI — CollectionPhotoSheet, gallery integration
+- Slice 3 (#139): ContributeDialog with disclaimers
+- Slice 4 (#140): Add-by-Photo integration
+
+## Status
+
+✅ COMPLETE

--- a/docs/plans/Collection_Item_Photos_Plan.md
+++ b/docs/plans/Collection_Item_Photos_Plan.md
@@ -1,0 +1,245 @@
+# Collection Item Photos + Catalog Contribution — Phase 1.6
+
+## Problem
+
+Users can catalog their toy collections but cannot attach their own photos. The existing photo system (Phase 1.9) is curator-managed catalog photos — shared reference images visible to all users. Collectors need private, per-item photos of their own physical copies (condition documentation, display shots, etc.).
+
+Additionally, user-contributed photos could feed back into the shared catalog and ML training pipeline, but this requires licensing disclaimers and curator approval.
+
+## Scope
+
+Four slices, delivered as an epic with sub-issues:
+
+1. **DB + API for collection item photos** — Migration, RLS-protected table, CRUD endpoints
+2. **Web UI for collection photos** — Photo management sheet, gallery integration in collection views
+3. **Contribution flow** — "Contribute to catalog" action with licensing disclaimers, pending approval
+4. **Add-by-Photo integration** — Save/contribute checkboxes in AddToCollectionDialog when opened from ML scan
+
+## Architecture Decisions
+
+### Two Photo Tables, One Storage Root
+
+Collection photos use a **separate table** (`collection_item_photos`) with RLS, parallel to the existing `item_photos` (no RLS). Both tables share `PHOTO_STORAGE_PATH` but use distinct directory layouts:
+
+```
+PHOTO_STORAGE_PATH/
+  {itemId}/                          # Catalog photos (existing)
+    {photoId}-thumb.webp
+    {photoId}-original.webp
+  collection/                        # Collection photos (new)
+    {userId}/
+      {collectionItemId}/
+        {photoId}-thumb.webp
+        {photoId}-original.webp
+```
+
+**Rationale:** User-scoped directories prevent cross-user enumeration at the filesystem level. The `collection/` prefix cleanly separates private from shared content. No new environment variable needed.
+
+### Contribution = File Copy, Not Link
+
+When a user contributes a collection photo to the catalog, the files are **copied** (not symlinked or hardlinked) to the catalog directory. This decouples lifecycles — a user deleting their collection photo doesn't break the catalog copy, and catalog photos may be served from a CDN with different access controls.
+
+### GDPR: Delete User Data, Keep Licensed Content + Audit Trail
+
+When `gdprPurgeUser()` runs:
+
+1. **Switch RLS context** to target user (`set_config('app.user_id', $targetId, true)`) — both `collection_item_photos` and `collection_items` have `FORCE ROW LEVEL SECURITY`, so the admin's context cannot access them
+2. **Delete collection item photos** — hard-delete all `collection_item_photos` rows for the user. `ON DELETE SET NULL` on `photo_contributions.collection_item_photo_id` preserves audit records
+3. **Delete collection items** — hard-delete all `collection_items` rows for the user (FK children already removed in step 2)
+4. **Scrub catalog photo attribution** — `UPDATE item_photos SET uploaded_by = NULL` for contributed photos (column is already nullable)
+5. **Delete photo files** — after transaction commits, `rm -rf PHOTO_STORAGE_PATH/collection/{userId}/` (best-effort, log failures)
+
+**What survives:**
+- `photo_contributions` rows (audit trail) — `collection_item_photo_id = NULL`, `contributed_by` → tombstone user, `item_photo_id` → surviving catalog photo, `consent_version` preserved
+- Contributed catalog photos (`item_photos` rows + files) — user granted a perpetual license; photo content (a toy) is not PII
+- `users` tombstone row — PII scrubbed, FKs intact
+
+**What is deleted:**
+- All `collection_item_photos` rows and files
+- All `collection_items` rows
+- `uploaded_by` attribution on catalog photos (set to NULL)
+
+### Contributions Require Curator Approval
+
+Contributed photos enter `item_photos` with `status: 'pending'`. Curators approve or reject via the existing `PhotoManagementSheet`. No new curator UI is needed — pending photos already appear in the management interface.
+
+### Add-by-Photo UX: Inline Checkboxes
+
+When `AddToCollectionDialog` receives a `photoFile` prop (from the ML scan flow), it shows two checkboxes below the condition/notes fields — keeping the flow single-step rather than a multi-step wizard. This minimizes friction for the most common case.
+
+## Database Schema
+
+### New Table: `collection_item_photos` (Migration 036)
+
+```sql
+CREATE TABLE public.collection_item_photos (
+    id                  UUID            PRIMARY KEY DEFAULT gen_random_uuid(),
+    collection_item_id  UUID            NOT NULL REFERENCES public.collection_items(id) ON DELETE RESTRICT,
+    user_id             UUID            NOT NULL REFERENCES public.users(id) ON DELETE RESTRICT,
+    url                 TEXT            NOT NULL,
+    caption             TEXT,
+    is_primary          BOOLEAN         NOT NULL DEFAULT false,
+    sort_order          INTEGER         NOT NULL DEFAULT 0,
+    dhash               TEXT            NOT NULL DEFAULT '',
+    created_at          TIMESTAMPTZ     NOT NULL DEFAULT now(),
+    updated_at          TIMESTAMPTZ     NOT NULL DEFAULT now()
+);
+
+-- RLS: ENABLE + FORCE, 4 policies using (SELECT current_app_user_id())
+-- Indexes: (collection_item_id, sort_order), partial unique on (collection_item_id) WHERE is_primary
+-- Trigger: update_updated_at
+```
+
+`user_id` is denormalized from `collection_items` because RLS policies evaluate per-row — a JOIN inside the policy expression would be expensive.
+
+### New Table: `photo_contributions` (Migration 036, same file)
+
+```sql
+CREATE TABLE public.photo_contributions (
+    id                          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    collection_item_photo_id    UUID        REFERENCES public.collection_item_photos(id) ON DELETE SET NULL,
+    item_photo_id               UUID        REFERENCES public.item_photos(id) ON DELETE SET NULL,
+    contributed_by              UUID        NOT NULL REFERENCES public.users(id) ON DELETE RESTRICT,
+    item_id                     UUID        NOT NULL REFERENCES public.items(id) ON DELETE RESTRICT,
+    consent_version             TEXT        NOT NULL,
+    consent_granted_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    file_copied                 BOOLEAN     NOT NULL DEFAULT false,
+    status                      TEXT        NOT NULL DEFAULT 'pending'
+                                CHECK (status IN ('pending', 'approved', 'rejected', 'revoked')),
+    created_at                  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at                  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- No RLS (shared application data, like item_photos)
+-- Unique index: (collection_item_photo_id) WHERE status != 'revoked'
+-- Indexes: (contributed_by), (item_id, status)
+```
+
+**Note:** `item_photos.uploaded_by` is already nullable (migration 011). No ALTER needed.
+
+## API Routes
+
+All under `/collection/:id/photos`, registered as a sub-plugin of `collectionRoutes`.
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| POST | `/collection/:id/photos` | Upload photos (multipart, max 10 files) |
+| GET | `/collection/:id/photos` | List photos for a collection item |
+| PATCH | `/collection/:id/photos/reorder` | Reorder photos |
+| PATCH | `/collection/:id/photos/:photoId/primary` | Set primary photo |
+| DELETE | `/collection/:id/photos/:photoId` | Hard-delete a photo |
+| POST | `/collection/:id/photos/:photoId/contribute` | Contribute to catalog |
+| DELETE | `/collection/:id/photos/:photoId/contribution` | Revoke contribution |
+
+Auth: `[fastify.authenticate, fastify.requireRole('user')]` — all authenticated users, RLS enforces ownership.
+
+### Content-Type Hook Update
+
+The `collectionRoutes` preValidation hook (line 162-169 of `api/src/collection/routes.ts`) currently rejects non-JSON content types. Must be updated to also accept `multipart/form-data` for photo upload routes.
+
+### Contribution Endpoint Flow
+
+1. Verify collection item + photo via RLS (ownership enforced by policy)
+2. Validate `consent_acknowledged === true` and `consent_version`
+3. Check no active contribution exists (unique index also enforces)
+4. Look up `collection_items.item_id` for catalog target
+5. Insert `photo_contributions` row (`status: 'pending'`, `file_copied: false`)
+6. Copy files from collection path to catalog path with new photo ID
+7. Reuse existing dhash (already computed on upload)
+8. Insert `item_photos` row with `status: 'pending'`, `uploaded_by: user.sub`
+9. Update `photo_contributions` with `item_photo_id` and `file_copied: true`
+
+## Web UI Design
+
+### CollectionPhotoSheet
+
+Mirrors `PhotoManagementSheet` (right panel Sheet, `sm:max-w-3xl`) with collection-scoped props. Composes existing `DropZone`, `UploadQueue`, and an extended `PhotoGrid`.
+
+**Extended photo tile actions:**
+- Star (set primary) — top-left, same as catalog
+- Contribute (Share2 icon) — bottom-left, gradient overlay, same opacity transition as delete
+- Delete (Trash2 icon) — bottom-right
+- "Contributed" badge — replaces contribute action when already contributed (`bg-amber-600/80 text-white text-[10px]`, same pattern as primary badge)
+
+### ContributeDialog
+
+Modal `Dialog` (`sm:max-w-md`) with:
+- Photo thumbnail preview (max-h-48, object-contain)
+- Disclaimer text in a subtle boxed callout (`bg-muted/50 border border-border p-3`)
+- Checkbox: "I confirm I have the right to share this photo" (requires Shadcn Checkbox install)
+- Submit button: amber accent, disabled until checkbox checked
+
+Consent version tracked as `'1.0'` — bumped when disclaimer text changes.
+
+### AddToCollectionDialog Enhancements
+
+When `photoFile?: File` prop is provided (from Add-by-Photo ML flow):
+- Labeled divider: "Photo Options" with horizontal rule
+- Photo preview row: 48x48 thumbnail + filename + file size
+- Checkbox: "Save this photo to your collection item" (default: checked)
+- Checkbox: "Contribute this photo to the catalog" (default: unchecked)
+- When contribute is checked, condensed disclaimer text expands below
+
+Submit chains: (1) create collection item, (2) upload photo if checked, (3) contribute if checked.
+
+### Collection Item Integration
+
+- **CollectionItemCard** (grid): Primary collection photo takes priority over catalog thumbnail. New Camera button in action row opens CollectionPhotoSheet. Photo count badge when count > 0.
+- **CollectionTable** (table): Same thumbnail priority logic. Camera icon in actions column.
+- API response gains `collection_photo_url: string | null` and `collection_photo_count: number` from LEFT JOIN.
+
+## Reused Modules
+
+| Module | Reuse Type |
+|--------|-----------|
+| `api/src/catalog/photos/thumbnails.ts` | Direct import (processUpload, DimensionError) |
+| `api/src/catalog/photos/dhash.ts` | Direct import (computeDHash, hammingDistance) |
+| `api/src/catalog/photos/storage.ts` | Import ensureDir, writePhoto; new collection-scoped path functions |
+| `web/src/catalog/photos/DropZone.tsx` | Direct use (generic, no domain coupling) |
+| `web/src/catalog/photos/UploadQueue.tsx` | Direct use |
+| `web/src/lib/photo-url.ts` | Direct use (buildPhotoUrl works with any relative URL) |
+
+## New Files
+
+### API
+- `api/db/migrations/036_collection_item_photos.sql`
+- `api/src/collection/photos/routes.ts`
+- `api/src/collection/photos/queries.ts`
+- `api/src/collection/photos/schemas.ts`
+- `api/src/collection/photos/storage.ts`
+- `api/src/collection/photos/routes.test.ts`
+
+### Web
+- `web/src/collection/photos/CollectionPhotoSheet.tsx`
+- `web/src/collection/photos/ContributeDialog.tsx`
+- `web/src/collection/photos/api.ts`
+- `web/src/collection/photos/useCollectionPhotoUpload.ts`
+- `web/src/collection/photos/useCollectionPhotoMutations.ts`
+
+## Photo Limits
+
+- Max photos per collection item: **10**
+- Max per upload request: **10**
+- Max file size: **10 MB** (reuses `config.photos.maxSizeMb`)
+- Min dimension: **600px** shortest edge (reuses `processUpload` validation)
+
+## Dependencies
+
+- Shadcn Checkbox component: `npx shadcn@latest add checkbox` (not yet installed)
+- No new npm packages required
+
+## Status
+
+- **Phase:** Architecture reviewed (3 passes, all medium+ resolved), documentation gate passed
+- **Epic issue:** #136 (sub-issues #137–#140)
+- **Depends on:** Phase 1.8 Slice 1 (collection items) ✅, Phase 1.9 (catalog photos) ✅
+
+## Architecture Review Notes
+
+Findings from the 3-pass architecture audit (see conversation for full details):
+
+1. **`item_photos.uploaded_by` already nullable** — migration 011 has no NOT NULL constraint. Removed unnecessary ALTER from migration.
+2. **GDPR RLS context mismatch** (HIGH) — `collection_item_photos` has FORCE RLS. Admin GDPR purge runs with admin's `app.user_id`, which can't see target user's rows. Resolved: temporarily switch RLS context via `set_config('app.user_id', $targetId, true)` inside `gdprPurgeUser`. Safe because subsequent operations touch only non-RLS tables.
+3. **`photo_contributions.collection_item_photo_id` FK conflict** (MEDIUM) — Changed from `NOT NULL ... ON DELETE RESTRICT` to nullable `ON DELETE SET NULL`. GDPR deletes collection photos; contribution audit records survive with NULL source reference.
+4. **GDPR must also delete `collection_items`** — user data, not audit trail. FK ordering: delete photos first, then items.
+5. **Contribute handler cleanup** — try/catch with best-effort file deletion if `item_photos` insert fails after catalog file copy (matches catalog upload pattern).

--- a/docs/test-scenarios/E2E_COLLECTION_PHOTOS.md
+++ b/docs/test-scenarios/E2E_COLLECTION_PHOTOS.md
@@ -1,0 +1,166 @@
+# E2E: Collection Item Photos
+
+## Background
+
+Given the web app is running
+And the user is signed in
+And the user has at least one item in their collection
+
+## Scenarios
+
+### Photo Upload
+
+```gherkin
+Scenario: User uploads a photo to their collection item
+  Given the user is on the collection page
+  When they click the camera icon on a collection item
+  Then the "Manage Photos" sheet opens on the right
+  When they drop a JPEG file into the drop zone
+  Then a progress bar appears showing upload status
+  And after upload completes, the photo appears in the grid
+  And a success notification is shown
+
+Scenario: User uploads multiple photos
+  Given the photo management sheet is open
+  When they select 3 files via the file picker
+  Then the upload queue shows 3 items
+  And files are uploaded sequentially with individual progress
+  And each photo appears in the grid after its upload completes
+
+Scenario: Upload shows error for invalid file type
+  Given the photo management sheet is open
+  When they drop a PDF file into the drop zone
+  Then an error toast appears mentioning supported formats
+  And no upload is initiated
+```
+
+### Photo Management
+
+```gherkin
+Scenario: User sets a photo as primary
+  Given the collection item has 2 photos
+  And the photo management sheet is open
+  When they click the star icon on the non-primary photo
+  Then that photo shows the filled star (primary badge)
+  And the previously primary photo shows an empty star
+
+Scenario: User reorders photos by drag and drop
+  Given the collection item has 3 photos
+  And the photo management sheet is open
+  When they drag the third photo to the first position
+  Then the photos reorder visually
+  And the new order persists after closing and reopening the sheet
+
+Scenario: User deletes a photo
+  Given the collection item has a photo
+  And the photo management sheet is open
+  When they click the delete (trash) icon on a photo
+  Then a confirmation dialog appears with "Delete photo?"
+  When they confirm the deletion
+  Then the photo is removed from the grid
+  And a success toast confirms the deletion
+```
+
+### Photo Display in Collection Views
+
+```gherkin
+Scenario: Collection grid shows primary collection photo
+  Given the user has uploaded a photo to a collection item
+  When they view the collection page in grid mode
+  Then the collection item card shows the user's photo as the thumbnail
+  And it does NOT show the catalog reference photo
+
+Scenario: Collection grid falls back to catalog photo
+  Given the user has NOT uploaded any photos to a collection item
+  When they view the collection page in grid mode
+  Then the collection item card shows the catalog reference photo thumbnail
+
+Scenario: Camera button shows photo count badge
+  Given a collection item has 3 photos
+  When the user views the collection page
+  Then the camera button on that item shows a "3" badge
+
+Scenario: Collection table shows thumbnail column
+  Given the user is viewing the collection in table mode
+  Then each row shows a small thumbnail (collection photo or catalog fallback)
+  And each row has a camera icon button in the actions column
+```
+
+### Contribute to Catalog
+
+```gherkin
+Scenario: User contributes a photo to the catalog
+  Given the photo management sheet is open
+  And the user has uploaded a photo
+  When they click the contribute (share) icon on a photo
+  Then the "Contribute Photo to Catalog" dialog appears
+  And it shows a photo preview
+  And it shows licensing disclaimer text
+  And the "Contribute to Catalog" button is disabled
+
+  When they check "I confirm I have the right to share this photo"
+  Then the "Contribute to Catalog" button becomes enabled
+
+  When they click "Contribute to Catalog"
+  Then a success toast says "Photo contributed for review"
+  And the dialog closes
+  And the photo tile shows a "Contributed" badge
+  And the contribute icon is no longer visible on that photo
+
+Scenario: Contributed badge persists after sheet reopen
+  Given a photo has been contributed
+  When the user closes and reopens the photo management sheet
+  Then the contributed photo still shows the "Contributed" badge
+
+Scenario: User cannot contribute the same photo twice
+  Given a photo already has a "Contributed" badge
+  Then there is no contribute action available on that photo tile
+```
+
+### Add-by-Photo Integration
+
+```gherkin
+Scenario: Add-by-Photo shows photo save checkboxes
+  Given the user is on the collection page
+  When they click "Add by Photo"
+  And upload a toy photo for ML identification
+  And the model returns predictions
+  When they click "Add" on a prediction card
+  Then the "Add to Collection" dialog shows the standard fields (condition, notes)
+  And below those, a "Photo Options" section appears
+  And it shows a thumbnail preview of the scanned photo
+  And "Save this photo to your collection item" is checked by default
+  And "Contribute this photo to the catalog" is unchecked by default
+
+Scenario: User adds item with photo saved
+  Given the Add to Collection dialog is open from Add-by-Photo
+  And "Save this photo to your collection item" is checked
+  And "Contribute this photo to the catalog" is unchecked
+  When they click "Add to Collection"
+  Then the collection item is created
+  And the scanned photo is uploaded to the new collection item
+  And a success toast confirms the addition
+
+Scenario: User adds item with photo saved and contributed
+  Given the Add to Collection dialog is open from Add-by-Photo
+  And "Save this photo to your collection item" is checked
+  When they check "Contribute this photo to the catalog"
+  Then condensed disclaimer text expands below the checkbox
+  When they click "Add to Collection"
+  Then the collection item is created
+  And the scanned photo is uploaded to the new collection item
+  And the photo is contributed to the catalog (pending approval)
+  And a success toast confirms the addition
+
+Scenario: User adds item without saving photo
+  Given the Add to Collection dialog is open from Add-by-Photo
+  When they uncheck "Save this photo to your collection item"
+  Then the "Contribute" checkbox becomes hidden (no photo to contribute)
+  When they click "Add to Collection"
+  Then the collection item is created without any photo
+
+Scenario: Standard Add to Collection dialog has no photo options
+  Given the user opens "Add to Collection" from a catalog item page (not Add-by-Photo)
+  Then the dialog shows condition, condition grade, and notes fields
+  But there are no "Photo Options" checkboxes
+```

--- a/docs/test-scenarios/INT_COLLECTION_PHOTOS.md
+++ b/docs/test-scenarios/INT_COLLECTION_PHOTOS.md
@@ -1,0 +1,238 @@
+# INT: Collection Item Photos API
+
+## Background
+
+Given the API server is running
+And the database has an item "optimus-prime" in franchise "transformers"
+And user A has a collection item for "optimus-prime"
+And user B has a separate collection item for "optimus-prime"
+
+## Scenarios
+
+### Upload
+
+```gherkin
+Scenario: User uploads a single photo to their collection item
+  Given user A is authenticated
+  When they POST a multipart request with one JPEG file to /collection/{itemId}/photos
+  Then the response status is 201
+  And the response body contains a photos array with 1 entry
+  And the photo has a relative URL under collection/{userId}/{collectionItemId}/
+  And two files exist on disk: thumb and original (both WebP)
+
+Scenario: User uploads multiple photos in one request
+  Given user A is authenticated
+  When they POST a multipart request with 3 image files
+  Then the response status is 201
+  And the response body contains a photos array with 3 entries
+  And each photo has a sequential sort_order
+
+Scenario: Upload rejected without authentication
+  Given no Authorization header is provided
+  When they POST a multipart upload
+  Then the response status is 401
+
+Scenario: Upload rejected for non-existent collection item
+  Given user A is authenticated
+  When they POST to /collection/{nonexistent-id}/photos
+  Then the response status is 404
+
+Scenario: Upload rejected for another user's collection item (RLS)
+  Given user A is authenticated
+  When they POST a photo to user B's collection item
+  Then the response status is 404
+  And no files are written to disk
+
+Scenario: Upload rejected for invalid image format
+  Given user A is authenticated
+  When they POST a file with mimetype "text/plain"
+  Then the response status is 400
+
+Scenario: Upload rejected for SVG (XSS risk)
+  Given user A is authenticated
+  When they POST a file with mimetype "image/svg+xml"
+  Then the response status is 400
+
+Scenario: Upload rejected when image dimensions are too small
+  Given user A is authenticated
+  When they POST an image smaller than 600px on shortest edge
+  Then the response status is 400
+  And the error mentions minimum dimension
+
+Scenario: Upload detects duplicate within same collection item
+  Given user A has a photo on their collection item
+  When they upload a perceptually similar photo (dHash distance <= 10)
+  Then the response status is 409
+  And the response includes the matched photo id and url
+
+Scenario: Upload succeeds for same photo on different collection items
+  Given user A has a photo on collection item 1
+  When they upload the same photo to collection item 2
+  Then the response status is 201
+  And deduplication only checks within the target collection item
+```
+
+### List
+
+```gherkin
+Scenario: User lists photos for their collection item
+  Given user A has 3 photos on their collection item
+  When they GET /collection/{itemId}/photos
+  Then the response status is 200
+  And the response contains 3 photos ordered by is_primary DESC, sort_order ASC
+
+Scenario: User cannot list photos for another user's collection item (RLS)
+  Given user B has photos on their collection item
+  When user A sends GET /collection/{userB-itemId}/photos
+  Then the response status is 404
+
+Scenario: List returns empty array for item with no photos
+  Given user A's collection item has no photos
+  When they GET /collection/{itemId}/photos
+  Then the response status is 200
+  And the response contains an empty photos array
+```
+
+### Delete
+
+```gherkin
+Scenario: User deletes their own photo
+  Given user A has a photo on their collection item
+  When they send DELETE /collection/{itemId}/photos/{photoId}
+  Then the response status is 204
+  And the photo row is removed from the database
+  And the photo files are removed from disk
+
+Scenario: Delete returns 404 for non-existent photo
+  Given no photo with that id exists for the collection item
+  When the user sends DELETE
+  Then the response status is 404
+
+Scenario: User cannot delete another user's photo (RLS)
+  Given user B has a photo on their collection item
+  When user A sends DELETE for that photo
+  Then the response status is 404
+  And the photo files remain on disk
+
+Scenario: Deleting a contributed photo does not delete the catalog copy
+  Given user A has contributed a photo to the catalog
+  When user A deletes the original collection photo
+  Then the response status is 204
+  And the collection photo files are removed
+  But the catalog photo files remain intact
+  And the photo_contributions row is preserved
+```
+
+### Set Primary
+
+```gherkin
+Scenario: User sets a photo as primary
+  Given user A has 2 photos, photo-1 is primary
+  When they PATCH /collection/{itemId}/photos/{photo-2}/primary
+  Then the response status is 200
+  And photo-2 is now primary
+  And photo-1 is no longer primary
+
+Scenario: Setting primary on already-primary photo is idempotent
+  Given photo-1 is already primary
+  When they PATCH to set photo-1 as primary
+  Then the response status is 200
+  And photo-1 remains primary
+```
+
+### Reorder
+
+```gherkin
+Scenario: User reorders photos
+  Given user A has 3 photos [a, b, c]
+  When they PATCH /collection/{itemId}/photos/reorder with [c, a, b]
+  Then the response status is 200
+  And the photos are returned in the new order
+  And each photo has the updated sort_order
+```
+
+### Contribute to Catalog
+
+```gherkin
+Scenario: User contributes a photo to the catalog
+  Given user A has a photo on their collection item
+  And the collection item references catalog item "optimus-prime"
+  When they POST /collection/{itemId}/photos/{photoId}/contribute
+  With body { "consent_version": "1.0", "consent_acknowledged": true }
+  Then the response status is 201
+  And a photo_contributions row is created with status "pending"
+  And an item_photos row is created with status "pending" and uploaded_by = user A
+  And the photo files are copied to the catalog directory {catalogItemId}/{newPhotoId}-*.webp
+  And the contribution row has file_copied = true
+
+Scenario: Contribution rejected without consent acknowledgement
+  Given user A has a photo
+  When they POST contribute with consent_acknowledged = false
+  Then the response status is 400
+
+Scenario: Contribution rejected for already-contributed photo
+  Given user A already contributed this photo (status != 'revoked')
+  When they POST contribute again
+  Then the response status is 409
+
+Scenario: Contribution rejected for another user's photo (RLS)
+  Given user B has a photo
+  When user A attempts to contribute user B's photo
+  Then the response status is 404
+
+Scenario: User revokes their contribution
+  Given user A contributed a photo (status = 'pending' or 'approved')
+  When they DELETE /collection/{itemId}/photos/{photoId}/contribution
+  Then the response status is 200
+  And the contribution status is set to 'revoked'
+  And the catalog item_photos row is NOT deleted (curator manages catalog)
+```
+
+### GDPR Purge
+
+```gherkin
+Scenario: GDPR purge deletes all collection photos and collection items
+  Given user A has 5 collection photos across 3 collection items
+  When an admin runs GDPR purge for user A
+  Then all collection_item_photos rows for user A are deleted
+  And all collection_items rows for user A are deleted
+  And all files under collection/{userA-id}/ are removed from disk
+
+Scenario: GDPR purge preserves contribution audit records
+  Given user A has 2 contributions (one pending, one approved)
+  When an admin runs GDPR purge for user A
+  Then the photo_contributions rows are preserved
+  And their collection_item_photo_id is NULL (source photo deleted via ON DELETE SET NULL)
+  And their contributed_by still references the tombstone user row
+  And their item_photo_id still references the surviving catalog photo
+  And their consent_version is preserved
+
+Scenario: GDPR purge anonymizes contributed catalog photos
+  Given user A contributed 2 photos that were approved in the catalog
+  When an admin runs GDPR purge for user A
+  Then the item_photos rows have uploaded_by = NULL
+  But the catalog photo files remain intact
+  And the photos are still visible in the catalog
+
+Scenario: GDPR purge uses RLS context switch for FORCE RLS tables
+  Given user A has collection items and photos
+  When an admin runs GDPR purge for user A
+  Then the purge switches app.user_id to the target user for RLS-protected deletes
+  And subsequent non-RLS operations (item_photos, photo_contributions) succeed
+```
+
+### Collection List Integration
+
+```gherkin
+Scenario: Collection list includes photo metadata
+  Given user A has a collection item with 3 photos (one primary)
+  When they GET /collection
+  Then each collection item in the response includes collection_photo_url and collection_photo_count
+  And collection_photo_url is the primary photo's thumbnail URL
+  And collection_photo_count is 3
+
+Scenario: Collection item with no photos returns null photo URL
+  Given user A has a collection item with no photos
+  When they GET /collection
+  Then the item has collection_photo_url = null and collection_photo_count = 0
+```

--- a/docs/test-scenarios/README.md
+++ b/docs/test-scenarios/README.md
@@ -44,6 +44,8 @@ See [TESTING_SCENARIOS.md](../guides/TESTING_SCENARIOS.md) for the scenario-driv
 | [INT_Seed_Sync.md](INT_Seed_Sync.md)                               | `api/db/seed/sync.test.ts`                                                                                                                                    | Scenarios written                       |
 | [UNIT_CATALOG_DETAIL_SHEETS.md](UNIT_CATALOG_DETAIL_SHEETS.md)     | `web/src/catalog/components/__tests__/DetailSheet.test.tsx`, `*DetailSheet.test.tsx`                                                                          | ✅ Implemented                          |
 | [E2E_ML_PHOTO_IDENTIFICATION.md](E2E_ML_PHOTO_IDENTIFICATION.md)  | `web/e2e/add-by-photo.spec.ts`, `web/e2e/admin-ml-stats.spec.ts`                                                                                            | ✅ Implemented                          |
+| [INT_COLLECTION_PHOTOS.md](INT_COLLECTION_PHOTOS.md)               | `api/src/collection/photos/routes.test.ts`                                                                                                                    | ✅ Implemented                          |
+| [E2E_COLLECTION_PHOTOS.md](E2E_COLLECTION_PHOTOS.md)               | `web/e2e/collection-photos.spec.ts`                                                                                                                           | Scenarios written                       |
 
 ## Creating a New Scenario
 


### PR DESCRIPTION
## Summary

- Add migration 036 with `collection_item_photos` (RLS, FORCE) and `photo_contributions` (audit) tables
- Implement 7 API routes under `/collection/:id/photos` for upload, list, reorder, set-primary, delete, contribute, and revoke contribution
- Extend `gdprPurgeUser()` with RLS context switch to delete collection photos + items, preserve contribution audit records, and scrub catalog photo attribution
- Reuse catalog photo pipeline (Sharp thumbnails, dHash dedup) with collection-scoped storage layout

Closes #137

## Test plan

- [x] 22 new integration tests pass (`api/src/collection/photos/routes.test.ts`)
- [x] All 831 existing tests continue to pass
- [x] 0 lint errors, clean TypeScript build
- [x] Verify migration applies cleanly on a fresh database
- [ ] Manual test: upload a photo to a collection item via API
- [ ] Manual test: contribute a photo and verify it appears as pending in `item_photos`
- [ ] Manual test: GDPR purge deletes collection data and preserves contribution audit

🤖 Generated with [Claude Code](https://claude.com/claude-code)