### PR TITLE
feat(web): add-by-photo collection photo integration (#140)

### DIFF
--- a/changelog/2026-04-06T214737Z_add-by-photo-integration-slice4.md
+++ b/changelog/2026-04-06T214737Z_add-by-photo-integration-slice4.md
@@ -1,0 +1,105 @@
+# Add-by-Photo Collection Photo Integration (Slice 4)
+
+**Date:** 2026-04-06
+**Time:** 21:47:37 UTC
+**Type:** Feature
+**Phase:** 1.6
+**Version:** v0.16.0
+
+## Summary
+
+Final slice of Phase 1.6 (Collection Item Photos). When a user identifies a toy via the
+Add-by-Photo ML flow and clicks "Add", the resulting Add to Collection dialog now offers two
+checkboxes for handling the scanned photo: save it to the new collection item, and optionally
+contribute it to the shared catalog. The dialog chains create → upload → contribute in a single
+submit, with isolated failure handling so a photo upload error never rolls back a successful item
+creation.
+
+---
+
+## Changes Implemented
+
+### 1. `usePhotoIdentify` — Expose Current File
+
+- Added `getCurrentFile()` returning `fileRef.current` so consumers can access the in-flight scan
+  file without restructuring the existing ref-based state machine
+- No behavioral change to identify/altMode/reset paths
+
+### 2. `AddByPhotoSheet` + `PredictionCard` — Thread File Through
+
+- `AddByPhotoSheet` reads `getCurrentFile()` and passes it to each `PredictionCard`
+- `PredictionCard` accepts a new optional `photoFile?: File` prop and forwards it to
+  `AddToCollectionDialog`
+- No-op when not in the Add-by-Photo flow (e.g., catalog item page entry point)
+
+### 3. `AddToCollectionDialog` — Photo Options Section
+
+- New optional `photoFile?: File` prop. When present, renders a "Photo Options" section below
+  the existing condition/notes fields with:
+  - 48×48 thumbnail preview (via `URL.createObjectURL`, cleaned up on unmount)
+  - Filename and human-readable file size
+  - "Save this photo to your collection item" checkbox (default: checked)
+  - "Contribute this photo to the catalog" checkbox (default: unchecked, hidden when save is
+    unchecked)
+  - Inline condensed disclaimer that appears only when contribute is checked
+- Submit chain:
+  1. `mutations.add.mutate(...)` creates the collection item
+  2. On success, success toast + (if no photo) close immediately
+  3. Otherwise IIFE: `uploadCollectionPhoto(newId, file)` → optional
+     `contributeCollectionPhoto(newId, photoId, '1.0')`
+  4. Each step has its own try/catch — failures show targeted toasts but the dialog still closes
+     in `finally` because the item was already created
+- New local state: `savePhoto`, `contributePhoto`, `isChaining`. All reset on dialog reopen.
+- `isPending` derives from `mutations.add.isPending || isChaining` and disables every control
+  through all three async stages
+
+### 4. Tests
+
+- New `AddToCollectionDialog.test.tsx` with 11 unit tests covering:
+  - Photo Options section visibility (with/without `photoFile`)
+  - Default checkbox state (save checked, contribute unchecked)
+  - Photo preview rendering with formatted size
+  - Hiding contribute checkbox when save is unchecked
+  - Conditional inline disclaimer display
+  - Item-only path (no photo)
+  - Upload-only path (save checked, contribute unchecked)
+  - Full chain (save + contribute, both succeed)
+  - Save unchecked skips upload entirely
+  - Upload failure: error toast fires, dialog still closes
+  - Contribute failure: error toast fires, upload result preserved
+- All 11 new tests pass; existing `AddByPhotoSheet` tests still pass
+
+## Decisions Made
+
+- **Approach C — inline chain, direct API calls**: Rejected extracting a `useAddByPhotoFlow` hook
+  (premature abstraction with one caller) and rejected using `useCollectionPhotoMutations`
+  (parameterized by collection item ID at hook-call time, which we don't have until `add` resolves)
+- **Partial-failure UX**: Item creation is the commit point. Upload and contribute are best-effort
+  with their own toasts. The user keeps their item even if the photo step fails — surprising
+  rollback would lose data
+- **`onSuccess` callback signature unchanged**: Issue spec suggested adding `(collectionItemId)`
+  but no existing caller needs the ID. Avoided cascading signature changes across `PredictionCard`,
+  `CollectionPage`, etc. until a caller actually needs it
+- **Telemetry**: Reused existing `prediction_accepted` event. Contribution telemetry is captured
+  server-side via `photo_contributions` rows; a separate ML event would be redundant
+
+## Files Modified
+
+- `web/src/collection/hooks/usePhotoIdentify.ts` — added `getCurrentFile()`
+- `web/src/collection/components/AddByPhotoSheet.tsx` — passes file to PredictionCard
+- `web/src/collection/components/PredictionCard.tsx` — new `photoFile?: File` prop
+- `web/src/collection/components/AddToCollectionDialog.tsx` — photo checkboxes + chained submit
+- `web/src/collection/components/__tests__/AddToCollectionDialog.test.tsx` — new file (11 tests)
+
+## Verification
+
+- `npm run typecheck` ✅
+- `npm run lint` ✅
+- `npx vitest run AddToCollectionDialog.test.tsx` ✅ (11/11)
+- `npx vitest run AddByPhotoSheet.test.tsx` ✅ (4/4 — no regressions)
+
+## Next Steps
+
+- E2E test for the happy-path "save + contribute" flow (deferred — matches Slices 1-3 deferral)
+- Phase 1.6 epic #136 can now be marked complete pending PR merge
+- Phase 2.0 (iOS) or Phase 1.12 (GDPR account deletion) are the remaining roadmap candidates

--- a/web/src/collection/components/AddByPhotoSheet.tsx
+++ b/web/src/collection/components/AddByPhotoSheet.tsx
@@ -20,7 +20,7 @@ interface AddByPhotoSheetProps {
 
 export function AddByPhotoSheet({ open, onOpenChange, mutations }: AddByPhotoSheetProps) {
   const { data: modelsData, isPending: modelsLoading } = useMlModels();
-  const { phase, activeCategory, identify, tryAltMode, reset } = usePhotoIdentify();
+  const { phase, activeCategory, identify, tryAltMode, reset, getCurrentFile } = usePhotoIdentify();
 
   // Track whether a terminal event (accepted/browse) already fired this session
   const hasTerminalEventRef = useRef(false);
@@ -48,7 +48,8 @@ export function AddByPhotoSheet({ open, onOpenChange, mutations }: AddByPhotoShe
 
   const handlePredictionAccepted = useCallback(() => {
     hasTerminalEventRef.current = true;
-  }, []);
+    onOpenChange(false);
+  }, [onOpenChange]);
 
   const handleBrowseCatalog = useCallback(() => {
     hasTerminalEventRef.current = true;
@@ -150,6 +151,7 @@ export function AddByPhotoSheet({ open, onOpenChange, mutations }: AddByPhotoShe
                       activeModel={activeModel}
                       mutations={mutations}
                       onAccepted={handlePredictionAccepted}
+                      photoFile={getCurrentFile() ?? undefined}
                     />
                   ))}
                 </div>

--- a/web/src/collection/components/AddToCollectionDialog.tsx
+++ b/web/src/collection/components/AddToCollectionDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 import {
   Dialog,
@@ -9,12 +9,16 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
 import { ConditionSelector } from '@/collection/components/ConditionSelector';
 import { ItemConditionSelector } from '@/collection/components/ItemConditionSelector';
 import { NotesField } from '@/collection/components/NotesField';
 import { DEFAULT_ITEM_CONDITION } from '@/collection/lib/item-condition-config';
+import { uploadCollectionPhoto, contributeCollectionPhoto } from '@/collection/photos/api';
 import type { PackageCondition } from '@/lib/zod-schemas';
 import type { CollectionMutations } from '@/collection/hooks/useCollectionMutations';
+
+const CONSENT_VERSION = '1.0';
 
 interface AddToCollectionDialogProps {
   open: boolean;
@@ -24,6 +28,13 @@ interface AddToCollectionDialogProps {
   alreadyOwned: boolean;
   mutations: CollectionMutations;
   onSuccess?: () => void;
+  photoFile?: File;
+}
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
 }
 
 export function AddToCollectionDialog({
@@ -34,18 +45,35 @@ export function AddToCollectionDialog({
   alreadyOwned,
   mutations,
   onSuccess,
+  photoFile,
 }: AddToCollectionDialogProps) {
   const [packageCondition, setPackageCondition] = useState<PackageCondition>('unknown');
   const [itemCondition, setItemCondition] = useState(DEFAULT_ITEM_CONDITION);
   const [notes, setNotes] = useState('');
+  const [savePhoto, setSavePhoto] = useState(true);
+  const [contributePhoto, setContributePhoto] = useState(false);
+  const [isChaining, setIsChaining] = useState(false);
 
   useEffect(() => {
     if (open) {
       setPackageCondition('unknown');
       setItemCondition(DEFAULT_ITEM_CONDITION);
       setNotes('');
+      setSavePhoto(true);
+      setContributePhoto(false);
+      setIsChaining(false);
     }
   }, [open]);
+
+  // Object URL for photo preview thumbnail
+  const previewUrl = useMemo(() => (photoFile ? URL.createObjectURL(photoFile) : null), [photoFile]);
+  useEffect(() => {
+    return () => {
+      if (previewUrl) URL.revokeObjectURL(previewUrl);
+    };
+  }, [previewUrl]);
+
+  const isPending = mutations.add.isPending || isChaining;
 
   const handleSubmit = () => {
     mutations.add.mutate(
@@ -56,10 +84,41 @@ export function AddToCollectionDialog({
         notes: notes.trim() || undefined,
       },
       {
-        onSuccess: () => {
+        onSuccess: (createdItem) => {
           toast.success(`${itemName} added to your collection`);
-          onOpenChange(false);
-          onSuccess?.();
+
+          // Fast path: no photo to handle — close immediately
+          if (!photoFile || !savePhoto) {
+            onOpenChange(false);
+            onSuccess?.();
+            return;
+          }
+
+          // Chain: upload photo, then optionally contribute. Best-effort —
+          // failures show their own toast but do not roll back the item.
+          setIsChaining(true);
+          void (async () => {
+            try {
+              const uploaded = await uploadCollectionPhoto(createdItem.id, photoFile, () => {});
+              const newPhoto = uploaded[0];
+              if (contributePhoto && newPhoto) {
+                try {
+                  await contributeCollectionPhoto(createdItem.id, newPhoto.id, CONSENT_VERSION);
+                  toast.success('Photo contributed for review');
+                } catch (err) {
+                  const message = err instanceof Error ? err.message : 'Failed to contribute photo';
+                  toast.error(message);
+                }
+              }
+            } catch (err) {
+              const message = err instanceof Error ? err.message : 'Failed to upload photo';
+              toast.error(message);
+            } finally {
+              setIsChaining(false);
+              onOpenChange(false);
+              onSuccess?.();
+            }
+          })();
         },
         onError: (err) => {
           toast.error(err.message);
@@ -77,25 +136,73 @@ export function AddToCollectionDialog({
         </DialogHeader>
 
         <div className="space-y-4 py-4">
-          <ConditionSelector
-            value={packageCondition}
-            onChange={setPackageCondition}
-            disabled={mutations.add.isPending}
-          />
-          <ItemConditionSelector value={itemCondition} onChange={setItemCondition} disabled={mutations.add.isPending} />
-          <NotesField id="collection-notes" value={notes} onChange={setNotes} disabled={mutations.add.isPending} />
+          <ConditionSelector value={packageCondition} onChange={setPackageCondition} disabled={isPending} />
+          <ItemConditionSelector value={itemCondition} onChange={setItemCondition} disabled={isPending} />
+          <NotesField id="collection-notes" value={notes} onChange={setNotes} disabled={isPending} />
+
+          {photoFile && previewUrl && (
+            <div className="space-y-3 border-t border-border pt-4">
+              <p className="text-sm font-medium text-foreground">Photo Options</p>
+
+              <div className="flex items-center gap-3 rounded-md border border-border p-2">
+                <img
+                  src={previewUrl}
+                  alt="Scanned photo preview"
+                  className="h-12 w-12 rounded object-contain bg-muted"
+                />
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-sm text-foreground">{photoFile.name}</p>
+                  <p className="text-xs text-muted-foreground">{formatFileSize(photoFile.size)}</p>
+                </div>
+              </div>
+
+              <div className="flex items-start gap-2">
+                <Checkbox
+                  id="save-photo"
+                  checked={savePhoto}
+                  onCheckedChange={(checked) => setSavePhoto(checked === true)}
+                  disabled={isPending}
+                />
+                <label htmlFor="save-photo" className="text-sm leading-tight cursor-pointer">
+                  Save this photo to your collection item
+                </label>
+              </div>
+
+              {savePhoto && (
+                <div className="flex items-start gap-2">
+                  <Checkbox
+                    id="contribute-photo"
+                    checked={contributePhoto}
+                    onCheckedChange={(checked) => setContributePhoto(checked === true)}
+                    disabled={isPending}
+                  />
+                  <label htmlFor="contribute-photo" className="text-sm leading-tight cursor-pointer">
+                    Contribute this photo to the catalog
+                  </label>
+                </div>
+              )}
+
+              {savePhoto && contributePhoto && (
+                <div className="rounded-md border border-border bg-muted/50 p-3 text-xs text-muted-foreground">
+                  By contributing, you grant Track&apos;em Toys a perpetual, non-exclusive, royalty-free license to use,
+                  display, and modify this photo for catalog and ML training. Contributions are pending curator review
+                  and can be revoked later.
+                </div>
+              )}
+            </div>
+          )}
         </div>
 
         <DialogFooter>
-          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+          <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={isPending}>
             Cancel
           </Button>
           <Button
             onClick={handleSubmit}
-            disabled={mutations.add.isPending}
+            disabled={isPending}
             className="bg-amber-600 hover:bg-amber-700 text-white dark:bg-amber-500 dark:hover:bg-amber-600"
           >
-            {mutations.add.isPending ? 'Adding...' : 'Add to Collection'}
+            {isPending ? 'Adding...' : 'Add to Collection'}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/web/src/collection/components/PredictionCard.tsx
+++ b/web/src/collection/components/PredictionCard.tsx
@@ -43,6 +43,7 @@ interface PredictionCardProps {
   activeModel: MlModelSummary | undefined;
   mutations: CollectionMutations;
   onAccepted?: () => void;
+  photoFile?: File;
 }
 
 export function PredictionCard({
@@ -51,6 +52,7 @@ export function PredictionCard({
   activeModel,
   mutations,
   onAccepted,
+  photoFile,
 }: PredictionCardProps) {
   const [dialogOpen, setDialogOpen] = useState(false);
   const { franchiseSlug, itemSlug, confidence } = prediction;
@@ -140,6 +142,7 @@ export function PredictionCard({
           alreadyOwned={alreadyOwned}
           mutations={mutations}
           onSuccess={handleAddSuccess}
+          photoFile={photoFile}
         />
       )}
     </div>

--- a/web/src/collection/components/__tests__/AddToCollectionDialog.test.tsx
+++ b/web/src/collection/components/__tests__/AddToCollectionDialog.test.tsx
@@ -1,0 +1,244 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AddToCollectionDialog } from '../AddToCollectionDialog';
+import type { CollectionMutations } from '@/collection/hooks/useCollectionMutations';
+import type { CollectionItem } from '@/lib/zod-schemas';
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+const mockUploadCollectionPhoto = vi.fn();
+const mockContributeCollectionPhoto = vi.fn();
+vi.mock('@/collection/photos/api', () => ({
+  uploadCollectionPhoto: (...args: unknown[]) => mockUploadCollectionPhoto(...args),
+  contributeCollectionPhoto: (...args: unknown[]) => mockContributeCollectionPhoto(...args),
+}));
+
+// jsdom lacks createObjectURL/revokeObjectURL
+beforeEach(() => {
+  Object.assign(URL, {
+    createObjectURL: vi.fn(() => 'blob:mock-url'),
+    revokeObjectURL: vi.fn(),
+  });
+  vi.clearAllMocks();
+});
+
+function makeMutations(overrides: Partial<{ addItem: CollectionItem }> = {}): CollectionMutations {
+  const defaultItem: CollectionItem = {
+    id: 'new-item-1',
+    item_id: 'cat-item-1',
+    user_id: 'u-1',
+    package_condition: 'unknown',
+    item_condition: 7,
+    notes: null,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    deleted_at: null,
+  } as unknown as CollectionItem;
+
+  const item = overrides.addItem ?? defaultItem;
+  const add = {
+    mutate: vi.fn(
+      (
+        _payload: unknown,
+        opts?: { onSuccess?: (data: CollectionItem) => void; onError?: (e: Error) => void }
+      ) => {
+        opts?.onSuccess?.(item);
+      }
+    ),
+    isPending: false,
+  };
+
+  return {
+    add,
+    patch: { mutate: vi.fn(), isPending: false },
+    remove: { mutate: vi.fn(), isPending: false },
+    restore: { mutate: vi.fn(), isPending: false },
+  } as unknown as CollectionMutations;
+}
+
+function makePhotoFile(name = 'optimus.jpg', sizeBytes = 2048): File {
+  const file = new File(['x'.repeat(sizeBytes)], name, { type: 'image/jpeg' });
+  Object.defineProperty(file, 'size', { value: sizeBytes });
+  return file;
+}
+
+const baseProps = {
+  open: true,
+  onOpenChange: vi.fn(),
+  itemId: 'cat-item-1',
+  itemName: 'Optimus Prime',
+  alreadyOwned: false,
+  mutations: makeMutations(),
+};
+
+describe('AddToCollectionDialog', () => {
+  it('does not render Photo Options section when photoFile is not provided', () => {
+    render(<AddToCollectionDialog {...baseProps} mutations={makeMutations()} />);
+
+    expect(screen.queryByText('Photo Options')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/Save this photo/)).not.toBeInTheDocument();
+  });
+
+  it('renders Photo Options with save checked and contribute unchecked by default', () => {
+    render(
+      <AddToCollectionDialog {...baseProps} mutations={makeMutations()} photoFile={makePhotoFile()} />
+    );
+
+    expect(screen.getByText('Photo Options')).toBeInTheDocument();
+    expect(screen.getByLabelText(/Save this photo/)).toBeChecked();
+    expect(screen.getByLabelText(/Contribute this photo/)).not.toBeChecked();
+  });
+
+  it('renders photo preview with filename and formatted size', () => {
+    render(
+      <AddToCollectionDialog
+        {...baseProps}
+        mutations={makeMutations()}
+        photoFile={makePhotoFile('shockwave.jpg', 1024 * 50)}
+      />
+    );
+
+    expect(screen.getByAltText('Scanned photo preview')).toHaveAttribute('src', 'blob:mock-url');
+    expect(screen.getByText('shockwave.jpg')).toBeInTheDocument();
+    expect(screen.getByText('50 KB')).toBeInTheDocument();
+  });
+
+  it('hides contribute checkbox when save is unchecked', async () => {
+    const user = userEvent.setup();
+    render(
+      <AddToCollectionDialog {...baseProps} mutations={makeMutations()} photoFile={makePhotoFile()} />
+    );
+
+    expect(screen.getByLabelText(/Contribute this photo/)).toBeInTheDocument();
+    await user.click(screen.getByLabelText(/Save this photo/));
+    expect(screen.queryByLabelText(/Contribute this photo/)).not.toBeInTheDocument();
+  });
+
+  it('shows inline disclaimer only when contribute is checked', async () => {
+    const user = userEvent.setup();
+    render(
+      <AddToCollectionDialog {...baseProps} mutations={makeMutations()} photoFile={makePhotoFile()} />
+    );
+
+    expect(screen.queryByText(/perpetual, non-exclusive, royalty-free license/)).not.toBeInTheDocument();
+    await user.click(screen.getByLabelText(/Contribute this photo/));
+    expect(screen.getByText(/perpetual, non-exclusive, royalty-free license/)).toBeInTheDocument();
+  });
+
+  it('creates item only (no upload) when no photoFile is provided', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    const mutations = makeMutations();
+
+    render(<AddToCollectionDialog {...baseProps} onOpenChange={onOpenChange} mutations={mutations} />);
+    await user.click(screen.getByRole('button', { name: 'Add to Collection' }));
+
+    expect(mutations.add.mutate).toHaveBeenCalled();
+    expect(mockUploadCollectionPhoto).not.toHaveBeenCalled();
+    expect(mockContributeCollectionPhoto).not.toHaveBeenCalled();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('uploads photo after item creation when save is checked', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    const file = makePhotoFile();
+    mockUploadCollectionPhoto.mockResolvedValue([{ id: 'photo-1', url: 'collection/u/c/p-original.webp' }]);
+
+    render(
+      <AddToCollectionDialog
+        {...baseProps}
+        onOpenChange={onOpenChange}
+        mutations={makeMutations()}
+        photoFile={file}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Add to Collection' }));
+
+    await waitFor(() => {
+      expect(mockUploadCollectionPhoto).toHaveBeenCalledWith('new-item-1', file, expect.any(Function));
+    });
+    expect(mockContributeCollectionPhoto).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+  });
+
+  it('uploads then contributes when both checkboxes are checked', async () => {
+    const { toast } = await import('sonner');
+    const user = userEvent.setup();
+    const file = makePhotoFile();
+    mockUploadCollectionPhoto.mockResolvedValue([{ id: 'photo-1', url: 'collection/u/c/p-original.webp' }]);
+    mockContributeCollectionPhoto.mockResolvedValue('contribution-1');
+
+    render(<AddToCollectionDialog {...baseProps} mutations={makeMutations()} photoFile={file} />);
+
+    await user.click(screen.getByLabelText(/Contribute this photo/));
+    await user.click(screen.getByRole('button', { name: 'Add to Collection' }));
+
+    await waitFor(() => {
+      expect(mockContributeCollectionPhoto).toHaveBeenCalledWith('new-item-1', 'photo-1', '1.0');
+    });
+    expect(toast.success).toHaveBeenCalledWith('Photo contributed for review');
+  });
+
+  it('skips upload when save is unchecked even with photoFile present', async () => {
+    const user = userEvent.setup();
+    const file = makePhotoFile();
+
+    render(<AddToCollectionDialog {...baseProps} mutations={makeMutations()} photoFile={file} />);
+
+    await user.click(screen.getByLabelText(/Save this photo/));
+    await user.click(screen.getByRole('button', { name: 'Add to Collection' }));
+
+    expect(mockUploadCollectionPhoto).not.toHaveBeenCalled();
+    expect(mockContributeCollectionPhoto).not.toHaveBeenCalled();
+  });
+
+  it('shows error toast but still closes when upload fails (item creation persists)', async () => {
+    const { toast } = await import('sonner');
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    const file = makePhotoFile();
+    mockUploadCollectionPhoto.mockRejectedValue(new Error('Network error'));
+
+    render(
+      <AddToCollectionDialog
+        {...baseProps}
+        onOpenChange={onOpenChange}
+        mutations={makeMutations()}
+        photoFile={file}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Add to Collection' }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('Network error');
+    });
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('shows contribute error but keeps upload success when contribute fails', async () => {
+    const { toast } = await import('sonner');
+    const user = userEvent.setup();
+    const file = makePhotoFile();
+    mockUploadCollectionPhoto.mockResolvedValue([{ id: 'photo-1', url: 'x' }]);
+    mockContributeCollectionPhoto.mockRejectedValue(new Error('Already contributed'));
+
+    render(<AddToCollectionDialog {...baseProps} mutations={makeMutations()} photoFile={file} />);
+
+    await user.click(screen.getByLabelText(/Contribute this photo/));
+    await user.click(screen.getByRole('button', { name: 'Add to Collection' }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('Already contributed');
+    });
+    // Photo upload still happened
+    expect(mockUploadCollectionPhoto).toHaveBeenCalled();
+  });
+});

--- a/web/src/collection/hooks/usePhotoIdentify.ts
+++ b/web/src/collection/hooks/usePhotoIdentify.ts
@@ -126,5 +126,7 @@ export function usePhotoIdentify() {
     setActiveCategory('primary');
   }, []);
 
-  return { phase, activeCategory, identify, tryAltMode, reset };
+  const getCurrentFile = useCallback(() => fileRef.current, []);
+
+  return { phase, activeCategory, identify, tryAltMode, reset, getCurrentFile };
 }

--- a/web/src/components/ui/sonner.tsx
+++ b/web/src/components/ui/sonner.tsx
@@ -7,6 +7,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
   return (
     <Sonner
       className="toaster group"
+      expand
       icons={{
         success: <CircleCheck className="h-4 w-4" />,
         info: <Info className="h-4 w-4" />,


### PR DESCRIPTION
## Summary
- Final slice of Phase 1.6 (#136). `AddToCollectionDialog` accepts optional `photoFile` and renders a Photo Options section: thumbnail preview, save + contribute checkboxes, inline disclaimer when contribute is checked.
- Submit chains create → upload → contribute with isolated try/catch per step. Item creation is the commit point — upload/contribute failures show their own toast but don't roll back the item.
- `usePhotoIdentify` exposes `getCurrentFile()`; `AddByPhotoSheet` threads the file through `PredictionCard` to the dialog.
- Fix Sonner stacking: enable `expand` on the global Toaster so multiple toasts lay out vertically with independent dismiss timers (previously z-stacked and appeared to close together).

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npx vitest run AddToCollectionDialog.test.tsx` (11/11 new tests)
- [x] `npx vitest run AddByPhotoSheet.test.tsx` (4/4, no regressions)
- [x] Manual: scan a toy → Add → verify save+contribute chain works end-to-end
- [x] Manual: verify two toasts stack vertically instead of overlapping

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)