### PR TITLE
docs(plans): photo approval dashboard + Phase 1.6 visibility amendment

### DIFF
--- a/docs/plans/Development_Roadmap_v1_0.md
+++ b/docs/plans/Development_Roadmap_v1_0.md
@@ -721,7 +721,7 @@ Three templates in `.github/ISSUE_TEMPLATE/`:
 | Issue | Title                                       | Labels                     | Effort | Track   |
 | ----- | ------------------------------------------- | -------------------------- | ------ | ------- |
 | #71   | Photo moderation: NSFW detection + approval | `api`, `web`, `phase:1.9b` | L      | Post-ML |
-| #72   | Approval notification dashboard             | `api`, `web`, `phase:1.9b` | M      | Post-ML |
+| #72   | Approval notification dashboard ([plan](Photo_Approval_Dashboard_Plan.md)) — depends on Phase 1.6 amendment ([plan](Photo_Contribution_Visibility_Plan.md)) | `api`, `web`, `phase:1.9b` | M      | Post-ML |
 | #73   | Soft delete + 30-day recycle bin            | `api`, `web`, `phase:1.9b` | M      | Post-ML |
 | #74   | Caption editing                             | `api`, `web`, `phase:1.9b` | S      | Post-ML |
 | #75   | Pending photo visibility                    | `api`, `web`, `phase:1.9b` | M      | Post-ML |

--- a/docs/plans/Photo_Approval_Dashboard_Plan.md
+++ b/docs/plans/Photo_Approval_Dashboard_Plan.md
@@ -1,0 +1,648 @@
+# Photo Approval Dashboard — Phase 1.9b
+
+## Problem
+
+Phase 1.6 shipped a contribution flow where users can submit their personal collection
+photos to the shared catalog. Each contribution creates a row in `item_photos` with
+`status: 'pending'`, awaiting curator approval. There is currently **no UI for curators to
+review or act on these pending photos** — they sit in the database with no visibility,
+no workflow, and no way to be promoted to `'approved'`.
+
+This dashboard addresses that gap: a curator-facing review interface that surfaces every
+pending photo (regardless of source), supports fast approve/reject decisions, and updates
+the contribution audit trail atomically.
+
+## Dependency: Phase 1.6 Visibility Amendment
+
+This dashboard plan **requires** the Phase 1.6 amendment (see
+[`Photo_Contribution_Visibility_Plan.md`](Photo_Contribution_Visibility_Plan.md)) to ship
+first. That amendment adds:
+
+- `item_photos.visibility` (`'public' | 'training_only'`)
+- `photo_contributions.intent` (`'training_only' | 'catalog_and_training'`)
+- Migration 037
+
+The dashboard plan below uses migration **038** (renumbered from 037) and assumes the
+visibility/intent columns already exist. The curator UI surfaces the contributor's intent
+and supports a "demote on approve" flow (`public → training_only`) but never promotes.
+
+## Scope
+
+Single-PR feature, not split into slices. Covers:
+
+- DB migration adding rejection-reason columns to `item_photos`
+- Three new admin API endpoints (list, decide, count)
+- New `/admin/photo-approvals` route with single-image triage UI
+- Notification dot on the admin nav link when pending count > 0
+- Keyboard-driven workflow (left-hand-only shortcuts)
+- Undo-last-decision via Sonner action button
+- Unit + integration + E2E tests
+
+**Out of scope** (deferred to follow-ups):
+
+- NSFW auto-moderation (#71 — separate feature, this dashboard works without it)
+- Background cleanup job for rejected files (separate issue, see "File Retention" below)
+- Bulk approve/reject (single-image triage is the v1 UX)
+- Approval history view (undo-last is the only retroactive action in v1)
+- Pagination (queue is bounded at 200 with a UI warning)
+
+## User & Use Case
+
+**Audience:** Curators (and admins via role inheritance). Realistic queue size in steady
+state: a handful to a few dozen pending photos. Curators want to clear the queue quickly
+with confident judgments based on visual inspection.
+
+**Workflow:**
+
+1. Curator notices the amber dot on the "Admin" nav link → clicks through to dashboard
+2. First pending photo loads, focused
+3. Curator inspects the hero image, glances at the 3 existing approved photos for the
+   same item (sidebar) to detect duplicates or quality regressions
+4. Presses **A** to approve (most common) — soft flash, photo slides left, next loads
+5. Or presses **R-R** (chord) to reject without reason, OR presses **1-6** to reject with
+   a preset reason (1=blurry, 2=wrong item, 3=NSFW, 4=duplicate, 5=poor quality, 6=other
+   → opens free-text input)
+6. If they hit the wrong key, the Sonner toast has an "Undo" button (5-second window)
+7. Queue empty → empty state with a serif "No photos awaiting review" message
+
+## Architecture Decisions
+
+### Validation Rules (Defense in Depth)
+
+The rejection reason columns are protected at three layers — DB constraints, Fastify
+schema, and endpoint handler logic — to prevent invalid combinations:
+
+| Rule | DB constraint | API schema | Handler |
+|---|---|---|---|
+| Code only when status='rejected' | ✓ | ✓ | clears on undo |
+| Text only when code='other' | ✓ | ✓ | clears when code changes |
+| `rejection_reason_text` length | — | `maxLength: 500` | — |
+| Status transition validity | — | enum check | `expected_status` (see below) |
+
+The endpoint handler always sets `rejection_reason_code = NULL, rejection_reason_text = NULL`
+in the same UPDATE statement when the target status is not `'rejected'`. This is required
+to avoid a transient state that violates the `code IS NULL OR status = 'rejected'`
+CHECK constraint during undo flows.
+
+### Two Rejection Reason Columns
+
+```sql
+ALTER TABLE item_photos
+  ADD COLUMN rejection_reason_code TEXT
+    CHECK (rejection_reason_code IN
+      ('blurry', 'wrong_item', 'nsfw', 'duplicate', 'poor_quality', 'other')),
+  ADD COLUMN rejection_reason_text TEXT;
+```
+
+Two columns instead of one because:
+
+- The **code** is queryable, translatable, and badge-friendly. ("Show me all NSFW
+  rejections this month" is a one-liner.)
+- The **text** is only used when `code = 'other'` — a free-form note. Storing them in one
+  column would force string parsing later.
+- A CHECK constraint enforces `text IS NULL OR code = 'other'` so the schema rejects
+  illegal combinations at insert time.
+- A second CHECK enforces `code IS NULL OR status = 'rejected'` so non-rejected rows
+  can't carry stale reason data.
+
+### Atomic Approve/Reject Across Two Tables
+
+When a curator approves a contributed photo, **both** the catalog row and the audit row
+flip in a single transaction:
+
+```sql
+BEGIN;
+UPDATE item_photos SET status = 'approved', updated_at = NOW()
+  WHERE id = $1 RETURNING id;
+UPDATE photo_contributions SET status = 'approved', updated_at = NOW()
+  WHERE item_photo_id = $1 AND status != 'revoked';
+COMMIT;
+```
+
+This keeps the contributor-facing badge ("Submitted" → "Shared") in lockstep with the
+catalog state. The same atomic flip applies to rejection. The Phase 1.6 list query
+already JOINs `photo_contributions.status` and expects it to track reality, so any drift
+would cause user-visible UI bugs.
+
+**WHERE clause uses `status != 'revoked'`, NOT `status = 'pending'`** — this is critical
+for the undo-and-redo flow. If a contribution was previously approved and is being
+re-approved after an undo, the `photo_contributions.status` is already `'approved'`, and
+filtering on `'pending'` would skip the row. The non-`'revoked'` filter handles every
+state the curator might transition.
+
+For **direct curator uploads** (no `photo_contributions` row), the second UPDATE simply
+affects 0 rows — that's fine.
+
+### Optimistic Concurrency
+
+The PATCH endpoint accepts an optional `expected_status` field in the request body. When
+provided, it's added to the WHERE clause: `UPDATE item_photos SET ... WHERE id = $1 AND
+status = $expected`. If the row's current status doesn't match (because another curator
+already decided), the UPDATE affects 0 rows and the endpoint returns **409 Conflict** with
+the actual current status. The client uses this to show "Photo state has changed —
+refreshing queue" and refetches.
+
+The 5-second undo window is **client-side UX only**. The PATCH endpoint imposes no
+server-side time limit on status edits — curators can retroactively change any photo's
+status at any time. This matches the existing Phase 1.9 catalog photo management pattern
+where curators can re-approve or re-reject without time restrictions.
+
+### Tombstoned Uploader Handling
+
+The uploader JOIN uses `LEFT JOIN users u ON ip.uploaded_by = u.id AND u.deleted_at IS NULL`.
+This means GDPR-tombstoned users (where `users.deleted_at IS NOT NULL` but the FK is
+intact) coerce to `uploader = null` in the API response, identical to the case where
+`uploaded_by IS NULL`. The UI shows `[REDACTED — GDPR]` for both. There is no halfway
+state where the curator sees a partial record like `{ display_name: null, email: null }`.
+
+### Single-Image Triage, Not a Grid
+
+The default (and v1's only) view is a single hero image with metadata sidebar and
+film-strip queue at the bottom. Reasons for not building a grid:
+
+- Curators are doing **judgment**, not **browsing**. Grids invite skimming, which lowers
+  decision quality on visual content.
+- The "existing photos" sidebar (3 most recent approved photos for the same item) is the
+  killer feature. It only fits in a single-image layout — a grid couldn't show it without
+  per-card clutter.
+- Keyboard-driven flow (A / R-R / 1-6 / S / D) requires a single "active photo" focus.
+  Grids force mouse selection.
+
+Grid view can be added as a `?view=grid` opt-in later if curators request it for fast
+skim-and-bulk-approve workflows.
+
+### Left-Hand-Only Keyboard Shortcuts
+
+All shortcuts cluster on the left side of a QWERTY keyboard so the curator's right hand
+stays free for the mouse (or coffee). The chord pattern for reject (R-R within 500ms)
+prevents accidental destructive actions while keeping single-key approve.
+
+| Key | Action |
+|---|---|
+| `A` | Approve as-intended (uses contributor's `intent` to set visibility) |
+| `T` | Approve as **training only** (no-op for `training_only` contributions; **demotes** `catalog_and_training` contributions to `training_only`) |
+| `R R` (chord) | Reject (no reason) |
+| `1` | Reject — blurry |
+| `2` | Reject — wrong item |
+| `3` | Reject — NSFW |
+| `4` | Reject — duplicate |
+| `5` | Reject — poor quality |
+| `6` | Reject — other (opens free-text input) |
+| `S` | Previous photo |
+| `D` | Next photo / skip |
+| `Esc` | Close any open overlay |
+
+**Approve vs Approve-as-Training-Only semantics:**
+
+- `A` (approve as-intended) sets `item_photos.visibility = 'public'` if the contributor's
+  intent was `catalog_and_training`, OR `'training_only'` if the contributor's intent
+  was `training_only`. The contributor's intent is honored.
+- `T` (approve as training-only) always sets `item_photos.visibility = 'training_only'`.
+  For `training_only`-intent contributions this is a no-op equivalent to `A`. For
+  `catalog_and_training`-intent contributions this is a **curator demote** — strictly
+  less exposure than the contributor consented to, which is allowed without re-consent.
+- There is **no shortcut for promoting `training_only → public`**. Promotion would
+  expand exposure beyond consent and requires a re-consent flow that's deferred to a
+  follow-up. The dashboard cannot promote.
+
+The keyboard handler:
+
+1. **Ignores any event with a modifier held** (`Ctrl`, `Cmd`, `Alt`, `Shift`). This
+   prevents `Cmd+R` (browser refresh) from triggering the R-R chord state.
+2. **Ignores keys when focus is in an `<input>` or `<textarea>`**, so the "other"
+   free-text box doesn't trigger shortcuts mid-typing.
+3. **Ignores keys while a mutation is in flight** for the current photo (so a second
+   press of A doesn't fire a duplicate request). Also resets the R-R chord state when a
+   mutation starts.
+4. **Ignores keys while any overlay is open** (KeyboardShortcutOverlay, RejectReasonOverlay
+   "other" input). Esc dismisses the open overlay; A/R/1-6 are inert until it closes.
+
+The chord window is a module-scoped constant `REJECT_CHORD_WINDOW_MS = 500`. Tests
+import the constant directly rather than hardcoding the value.
+
+### "Other" Reason — Inline Input Flow
+
+When the curator presses **6** or selects "Other" from the mouse dropdown, an **inline
+text input** appears below the action bar (NOT a separate modal). The input is auto-focused.
+
+- **Enter** confirms the rejection with `code='other'` and the typed text (or
+  `text=null` if empty)
+- **Esc** cancels the entire reject action and returns to the triage view
+- The text input has `maxLength={500}` matching the server-side schema constraint
+- Keyboard shortcuts are suppressed while the input is focused (per rule 2 above)
+
+### Undo-Last via Sonner Action Button
+
+Mirrors the existing collection delete-undo pattern:
+
+- After every approve/reject mutation, fire a Sonner toast with a 5-second duration and
+  an "Undo" action button
+- Undo button calls the same `PATCH /admin/photos/:id/status` endpoint with
+  `status: 'pending'` (and `rejection_reason_code: null, rejection_reason_text: null`),
+  reverting the row to its pre-decision state
+- Each toast has a unique `id` so concurrent decisions (curator approves Y while X's
+  toast is still visible) don't cross-wire callbacks
+- No history view, no audit timeline — undo is the only retroactive action in v1
+
+### File Retention on Reject
+
+Rejected photos **keep their files** in v1. The `item_photos` row stays with
+`status='rejected'` and the underlying file is untouched. This:
+
+- Allows undo to fully restore the photo (otherwise undo would leave a dangling row)
+- Allows curators to re-review rejected photos manually if they realize a mistake later
+- Defers the file-cleanup mechanism to a separate follow-up issue, which will introduce
+  a background job that deletes files for `item_photos WHERE status='rejected' AND
+  updated_at < NOW() - INTERVAL '30 days'`
+
+### No Pagination, No Polling
+
+- **No pagination**: the pending queue is bounded by curator workload (realistically
+  <100). The list endpoint returns up to 200 photos in one response with a `total_count`
+  field; the UI displays a warning if `total_count > 200`. The film-strip queue UI relies
+  on having the whole batch in memory for instant J/K-style navigation.
+- **No interval polling**: the notification dot fetches the count once per browser-tab
+  lifecycle (page load / refresh / new tab) via the TanStack Query cache, and invalidates
+  after every approve/reject/undo mutation. No `setInterval`, no 60-second refresh.
+  Curators are the only audience, see the dot when they care, and get immediate feedback
+  after their own actions.
+
+### Role Guard
+
+`requireRole('curator')` on every endpoint. Per the existing role hierarchy, this allows
+both `curator` and `admin` users (admin inherits curator). Photo approval is a curator
+concern by design; admins get it for free via inheritance.
+
+**An inline comment in `routes.ts` is required** to prevent future maintainers from
+"normalizing" the URL prefix `/admin/*` and the role check `requireRole('curator')` to
+match (e.g., changing curator to admin). The mismatch is intentional.
+
+### Empty `existing_photos` Behavior
+
+When the underlying item has zero approved photos (e.g., the pending photo is the
+first-ever contribution for that item), the `existing_photos` array is empty and the
+"Existing Photos" sidebar section is **not rendered at all**. No "No photos yet"
+placeholder, no empty heading — the section simply isn't part of the DOM.
+
+### Accessibility
+
+- **Headings**: page = `<h1>Photo Approvals</h1>`, triage view = `<h2>Reviewing {itemName}</h2>`,
+  empty state = `<h1>No photos awaiting review</h1>`
+- **Keyboard overlay**: `role="dialog"`, `aria-label="Keyboard shortcuts"`, dismissible
+  via Esc, focus-trapped while open
+- **Live region**: a visually-hidden `<div aria-live="polite">Reviewing photo {n} of {total}</div>`
+  on the triage view announces queue position to screen readers on every navigation
+- **Existing photos thumbnails**: `alt={`Existing photo for ${itemName}`}` and clickable
+  links to the catalog item page
+- **Action bar buttons**: have `aria-keyshortcuts="A"`, `"R R"`, etc. so assistive tech
+  can announce the shortcuts
+
+## Database — Migration 038
+
+```sql
+-- 038_item_photos_rejection_reasons.sql
+-- Depends on migration 037 (visibility + intent columns from Phase 1.6 amendment)
+
+ALTER TABLE item_photos
+  ADD COLUMN rejection_reason_code TEXT
+    CHECK (rejection_reason_code IN
+      ('blurry', 'wrong_item', 'nsfw', 'duplicate', 'poor_quality', 'other')),
+  ADD COLUMN rejection_reason_text TEXT;
+
+ALTER TABLE item_photos
+  ADD CONSTRAINT item_photos_rejection_text_only_other CHECK (
+    rejection_reason_text IS NULL OR rejection_reason_code = 'other'
+  );
+
+ALTER TABLE item_photos
+  ADD CONSTRAINT item_photos_rejection_code_only_rejected CHECK (
+    rejection_reason_code IS NULL OR status = 'rejected'
+  );
+
+CREATE INDEX idx_item_photos_pending_created
+  ON item_photos (created_at ASC) WHERE status = 'pending';
+```
+
+## API Endpoints
+
+All under `/admin/photos/*`, all gated by `[fastify.authenticate, fastify.requireRole('curator')]`.
+
+### `GET /admin/photos/pending`
+
+Returns the full pending queue (capped at 200) with all metadata needed for the
+single-image triage view.
+
+```typescript
+{
+  photos: Array<{
+    id: string;
+    item: {
+      id: string;
+      name: string;
+      slug: string;
+      franchise_slug: string;
+      thumbnail_url: string | null;
+    };
+    photo: {
+      url: string;
+      caption: string | null;
+      dhash: string;
+      visibility: 'public' | 'training_only';  // current visibility (curator may have demoted)
+    };
+    uploader: {
+      id: string;
+      display_name: string;
+      email: string;
+    } | null;  // null = uploaded_by IS NULL OR uploader is GDPR-tombstoned (deleted_at IS NOT NULL)
+    contribution: {
+      id: string;
+      consent_version: string;
+      consent_granted_at: string;
+      intent: 'training_only' | 'catalog_and_training';  // contributor's locked consent
+    } | null;  // null = direct curator upload (no contribution row); rare in v1, may not occur
+    existing_photos: Array<{
+      id: string;
+      url: string;
+    }>;  // up to 3 most recent approved photos for the same item
+    created_at: string;
+  }>;
+  total_count: number;  // unbounded count for the "200+" warning
+}
+```
+
+The query is one big SELECT with:
+
+- `LEFT JOIN users u ON ip.uploaded_by = u.id AND u.deleted_at IS NULL` — tombstoned
+  users coerce to `uploader = null`, identical to `uploaded_by IS NULL`
+- `LEFT JOIN photo_contributions pc ON pc.item_photo_id = ip.id AND pc.status != 'revoked'`
+  — revoked contributions are filtered so the curator never sees orphaned audit trails.
+  Additionally, `WHERE pc.file_copied = true OR pc.id IS NULL` excludes contributions
+  whose underlying file copy hasn't completed yet (Phase 1.6 crash-recovery state)
+- `LEFT JOIN LATERAL (SELECT id, url FROM item_photos WHERE item_id = ip.item_id AND
+  status = 'approved' ORDER BY created_at DESC LIMIT 3)` for the existing-photos preview
+- `WHERE ip.status = 'pending' ORDER BY ip.created_at ASC LIMIT 200`
+
+### `PATCH /admin/photos/:id/status`
+
+Decide a photo. Body:
+
+```typescript
+{
+  status: 'approved' | 'rejected' | 'pending';  // 'pending' is the undo path
+  expected_status?: 'pending' | 'approved' | 'rejected';  // optimistic concurrency
+  visibility?: 'training_only';  // OPTIONAL demote on approve. ONLY accepts 'training_only'.
+                                  // Promote ('public') is rejected with 422.
+  rejection_reason_code?: 'blurry' | 'wrong_item' | 'nsfw' | 'duplicate' | 'poor_quality' | 'other';
+  rejection_reason_text?: string;  // only allowed when code = 'other', max 500 chars
+}
+```
+
+**Validation**:
+
+- If `status === 'rejected'`, `rejection_reason_code` is **required**
+- If `rejection_reason_text` is provided, `rejection_reason_code` MUST be `'other'`
+- If `status !== 'rejected'`, the server **clears** `rejection_reason_code` and
+  `rejection_reason_text` in the same UPDATE (avoids the transient state that violates
+  the `code IS NULL OR status='rejected'` CHECK constraint)
+- `rejection_reason_text` `maxLength: 500`
+- `visibility` field is **only accepted as `'training_only'`** — it's a one-way demote
+  flag. Sending `visibility: 'public'` returns **422 Unprocessable Entity** with an error
+  about promotion requiring re-consent. Sending `visibility: 'training_only'` is allowed
+  for any approve action (no-op when contributor's intent was already `training_only`,
+  demote when intent was `catalog_and_training`).
+- `visibility` is only meaningful when `status === 'approved'`. Sending it with
+  `'rejected'` or `'pending'` is silently ignored — the column stays at its prior value
+  (it's NOT NULL, so it can't be cleared, and changing it would be irrelevant anyway
+  since rejected/pending photos aren't displayed to anyone except the curator).
+
+**Behavior**:
+
+- Atomic transaction. The `visibility` column is **path-independent** on approve actions:
+  pressing `A` always restores the contributor's intent, pressing `T` always sets
+  `training_only`. This means a curator can recover from a mistaken demote+undo cycle
+  by pressing `A` again. On non-approve actions (`reject` / `pending`), visibility is
+  left unchanged (it's irrelevant when the photo isn't visible anyway).
+
+  The endpoint computes the target visibility server-side **before** the UPDATE, by
+  reading the contributor's intent from `photo_contributions`:
+
+  ```typescript
+  // Pseudocode for the endpoint handler
+  const target_visibility = (status === 'approved')
+    ? (request.body.visibility === 'training_only'
+        ? 'training_only'                                        // T press: explicit demote
+        : (contribution?.intent === 'catalog_and_training'
+            ? 'public'                                           // A press, public intent
+            : 'training_only'))                                  // A press, training-only intent
+    : null;  // reject/pending: visibility unchanged
+  ```
+
+  Then the UPDATE:
+  ```sql
+  UPDATE item_photos
+    SET status = $1,
+        rejection_reason_code = $2,
+        rejection_reason_text = $3,
+        visibility = COALESCE($6, visibility),  -- $6 is target_visibility, NULL on undo/reject
+        updated_at = NOW()
+    WHERE id = $4
+      AND ($5::text IS NULL OR status = $5)    -- expected_status guard
+  RETURNING id;
+  ```
+
+  For direct curator uploads (no `photo_contributions` row), the contribution intent is
+  treated as `catalog_and_training` by default, so pressing `A` results in
+  `visibility = 'public'`.
+  If 0 rows affected → 409 Conflict with `{ error: 'Photo state has changed', current_status: <actual> }`.
+  Client refetches the queue.
+- Then:
+  ```sql
+  UPDATE photo_contributions
+    SET status = $1, updated_at = NOW()
+    WHERE item_photo_id = $2 AND status != 'revoked';
+  ```
+  Note: filters `!= 'revoked'`, NOT `= 'pending'`, so undo-and-redo flows work correctly.
+
+**Response**: returns the updated base `item_photos` row:
+```typescript
+{
+  id: string;
+  item_id: string;
+  url: string;
+  status: 'approved' | 'rejected' | 'pending';
+  visibility: 'public' | 'training_only';
+  rejection_reason_code: string | null;
+  rejection_reason_text: string | null;
+  updated_at: string;
+}
+```
+
+Client invalidates the `['admin', 'photos', 'pending']` query and the
+`['admin', 'photos', 'pending-count']` query on success.
+
+### `GET /admin/photos/pending-count`
+
+Lightweight count for the nav notification dot.
+
+```typescript
+{ count: number; }
+```
+
+`SELECT COUNT(*) FROM item_photos WHERE status = 'pending'`. No JOINs, no metadata.
+
+## Web Components
+
+| File | Purpose |
+|---|---|
+| `web/src/admin/photos/PhotoApprovalPage.tsx` | Top-level page; owns active photo state, queue navigation, keyboard shortcuts |
+| `web/src/admin/photos/PhotoTriageView.tsx` | Hero image + sidebar layout |
+| `web/src/admin/photos/PhotoMetadataPanel.tsx` | Item link, uploader info, contribution audit (with intent badge), current visibility, existing-photos strip |
+| `web/src/admin/photos/ActionBar.tsx` | Approve / Approve as Training-Only / Reject / Skip buttons + reason dropdown. The "Approve as Training-Only" button is hidden when contribution intent is already `training_only`. |
+| `web/src/admin/photos/RejectReasonOverlay.tsx` | Numeric-keyed reason picker with free-text for "other" |
+| `web/src/admin/photos/FilmStripQueue.tsx` | Bottom queue navigation, click-to-jump, position indicator |
+| `web/src/admin/photos/KeyboardShortcutOverlay.tsx` | First-visit cheat sheet, dismissible, localStorage-persisted |
+| `web/src/admin/photos/usePhotoApprovalKeyboard.ts` | Keyboard handler hook (A, R-R chord, 1-6, S, D, Esc) |
+| `web/src/admin/photos/usePhotoApprovals.ts` | TanStack Query hook for `GET /admin/photos/pending` |
+| `web/src/admin/photos/usePhotoApprovalMutations.ts` | Approve/reject/undo mutations with toast feedback |
+| `web/src/admin/photos/usePendingPhotoCount.ts` | Lightweight count hook for the nav dot |
+| `web/src/admin/photos/api.ts` | API client functions |
+| `web/src/routes/_authenticated/admin/photo-approvals.tsx` | Route registration |
+
+### Modified files
+
+- `api/src/admin/routes.ts` — register the photos sub-plugin
+- `web/src/lib/zod-schemas.ts` — add the schemas below
+- Admin sidebar component — add "Photo Approvals" link with notification dot
+- `web/playwright.config.ts` — register the new E2E spec
+
+### Zod Schemas (web/src/lib/zod-schemas.ts)
+
+```typescript
+export const PhotoApprovalUploaderSchema = z.object({
+  id: z.string().uuid(),
+  display_name: z.string(),
+  email: z.string(),
+});
+
+export const PhotoApprovalContributionSchema = z.object({
+  id: z.string().uuid(),
+  consent_version: z.string(),
+  consent_granted_at: z.string(),
+  intent: z.enum(['training_only', 'catalog_and_training']),
+});
+
+export const PhotoApprovalItemSchema = z.object({
+  id: z.string().uuid(),
+  item: z.object({
+    id: z.string().uuid(),
+    name: z.string(),
+    slug: z.string(),
+    franchise_slug: z.string(),
+    thumbnail_url: z.string().nullable(),
+  }),
+  photo: z.object({
+    url: z.string(),
+    caption: z.string().nullable(),
+    dhash: z.string(),
+    visibility: z.enum(['public', 'training_only']),
+  }),
+  uploader: PhotoApprovalUploaderSchema.nullable(),
+  contribution: PhotoApprovalContributionSchema.nullable(),
+  existing_photos: z.array(z.object({
+    id: z.string().uuid(),
+    url: z.string(),
+  })),
+  created_at: z.string(),
+});
+
+export const PhotoApprovalListResponseSchema = z.object({
+  photos: z.array(PhotoApprovalItemSchema),
+  total_count: z.number().int().nonnegative(),
+});
+
+export const PhotoApprovalDecisionResponseSchema = z.object({
+  id: z.string().uuid(),
+  item_id: z.string().uuid(),
+  url: z.string(),
+  status: z.enum(['pending', 'approved', 'rejected']),
+  visibility: z.enum(['public', 'training_only']),
+  rejection_reason_code: z.enum([
+    'blurry', 'wrong_item', 'nsfw', 'duplicate', 'poor_quality', 'other'
+  ]).nullable(),
+  rejection_reason_text: z.string().nullable(),
+  updated_at: z.string(),
+});
+
+export const PhotoApprovalConflictResponseSchema = z.object({
+  error: z.string(),
+  current_status: z.enum(['pending', 'approved', 'rejected']),
+});
+
+export const PhotoApprovalCountResponseSchema = z.object({
+  count: z.number().int().nonnegative(),
+});
+
+export type PhotoApprovalItem = z.infer<typeof PhotoApprovalItemSchema>;
+```
+
+## Test Plan
+
+| Layer | Coverage |
+|---|---|
+| API unit | Query functions: pending list shape, atomic flip, undo, count, validation |
+| API integration | Auth (401/403 for non-curator), happy paths, validation rejections (text without code='other', code without status='rejected'), atomic flip across both tables, undo round-trip |
+| Web unit | PhotoApprovalPage state machine, ActionBar callbacks, keyboard hook (A, **T (approve-as-training-only)**, R-R chord timing, 1-6, S, D, all four guards: modifier-held, input/textarea focus, in-flight mutation, overlay-open), FilmStripQueue navigation, "other" inline input flow (Enter/Esc), demote-on-approve flow (T on a public-intent photo updates visibility to training_only) |
+| E2E | Curator opens dashboard → approves with A → rejects with `1` → undoes via Sonner → demotes a public contribution with T → verifies it's no longer in the public catalog → empty state → notification dot disappears |
+
+Test scenarios in `docs/test-scenarios/E2E_PHOTO_APPROVAL.md` (Gherkin format).
+
+## Risks
+
+- **R1 — `LEFT JOIN LATERAL` performance.** The "existing photos" subquery runs once per
+  pending row. Mitigation: it's bounded to LIMIT 3 and the index on `(item_id, status)`
+  exists. Realistic v1 queue size (<100) makes this trivial.
+- **R2 — Large pending queues (>200).** Out of v1 scope per Q3. UI shows a warning, the
+  curator processes a batch, then refreshes for the next 200.
+- **R3 — Keyboard handler conflicts.** The handler explicitly skips events with any
+  modifier held (`Ctrl`/`Cmd`/`Alt`/`Shift`), so `Cmd+R` (browser refresh) never
+  triggers the R-R chord state. It also ignores keys when focus is on an
+  `<input>`/`<textarea>`, when an overlay is open, and when a mutation is in flight for
+  the current photo.
+- **R4 — Undo race condition.** Each toast's undo callback closes over the specific
+  `photoId` it acted on, not "the current photo". Sonner's per-toast `id` prevents
+  callback cross-wiring. The dashboard does NOT scroll back to the undone photo —
+  the user stays on whatever they're currently viewing, and the undone photo
+  re-enters the queue at its original position.
+- **R5 — Concurrent curator decisions.** Two curators decide the same photo simultaneously.
+  Mitigated by the `expected_status` optimistic concurrency check on the PATCH endpoint
+  — the second request returns 409 and the client refetches the queue.
+- **R6 — Pending photo files publicly served.** `@fastify/static` serves files by URL,
+  not by DB status. A user with the URL of a pending photo can view it before approval.
+  **This is a known privacy concern that v1 does NOT address** — see "Out-of-Scope
+  Followups" below. v1 mitigates by relying on URL un-guessability (UUID-based paths)
+  and acknowledging that the surface area is small (only contributions in the queue).
+- **R7 — File retention on reject leaks disk.** Acknowledged. Tracked as a follow-up
+  cleanup job issue.
+
+## Out-of-Scope Followups
+
+- **Pending photo file access control** (R6): currently `@fastify/static` serves all
+  photo files by URL regardless of DB status. A new follow-up issue should restrict
+  access to `status='pending'` photos — either by serving them through a gated endpoint
+  that checks `requireRole('curator')`, or by storing pending uploads under a separate
+  filesystem path that isn't behind `@fastify/static`. The simplest fix is the latter
+  — store contributed photos under `pending/` until approved, then move to the public
+  path on approval.
+- **NSFW auto-moderation** (#71): would auto-flag uploads, dashboard surfaces them
+  pre-filtered. Independent feature, this dashboard works without it.
+- **Background cleanup of rejected files**: scheduled job that deletes files for rejected
+  rows older than 30 days. New issue to be filed when this PR ships.
+- **Bulk approve/reject**: shift-click range selection in a grid view. Defer until
+  curators ask for it.
+- **Approval history / audit log page**: read-only view of past decisions, filterable by
+  curator and date. Defer.
+- **Reject reason analytics**: dashboard showing "what gets rejected most" to inform
+  contributor guidelines. Defer.
+- **Self-approval policy**: currently a curator can approve their own contributed photo.
+  Acceptable for v1 (audit trail in `photo_contributions.contributed_by` makes any abuse
+  visible). Could add a "cannot approve own contribution" guard later if abuse occurs.

--- a/docs/plans/Photo_Contribution_Visibility_Plan.md
+++ b/docs/plans/Photo_Contribution_Visibility_Plan.md
@@ -1,0 +1,294 @@
+# Photo Contribution Visibility (Training vs Catalog) — Phase 1.6 Amendment
+
+## Problem
+
+Phase 1.6 shipped a contribution flow that treats every contributed photo as both
+catalog-bound AND training-bound. There is no way for a contributor to say "use this
+photo for ML training only, but don't display it in the public catalog." This is a missed
+requirement: many contributors will be willing to help train the model with photos they
+do **not** want shown publicly (e.g., partial PII visible in the background, photos
+they're not proud of aesthetically, etc.).
+
+This amendment adds **contributor intent** to the contribution flow. Each contribution
+declares one of two intents:
+
+- **`training_only`** — used for ML training only, never shown in the public catalog
+- **`catalog_and_training`** — shown in the catalog AND used for ML training
+
+The intent is captured at consent time, locked into the audit trail, and drives whether
+the resulting `item_photos` row is publicly visible.
+
+## Why This Is a Phase 1.6 Amendment
+
+The contribution flow is owned by Phase 1.6 (#136). The Phase 1.9b approval dashboard
+(#72) needs to **read** the visibility/intent fields, but the data model + UI for setting
+them belongs to the contribution flow itself. Mixing them into the dashboard PR would:
+
+- Conflate two independent concerns (contribution UX vs curator UX)
+- Make the dashboard PR ~30% larger and harder to review
+- Hide a Phase 1.6 fix inside an unrelated phase's changelog
+
+This amendment ships **first** as a self-contained PR. The dashboard PR (#72) assumes
+the new schema exists and uses it.
+
+## Scope
+
+Single-PR amendment. Covers:
+
+- Migration adding `visibility` to `item_photos` and `intent` to `photo_contributions`
+- Backfill all existing rows to `training_only` (privacy-default)
+- Updated `POST /collection/:id/photos/:photoId/contribute` API endpoint to accept intent
+- Updated `ContributeDialog` with intent radio picker
+- Updated `AddToCollectionDialog` (Add-by-Photo) with intent radio (replaces the
+  contribute checkbox)
+- Updated catalog photo list query to filter `WHERE visibility = 'public'`
+- Updated ML training data exporter to include both visibilities
+- Unit + integration + E2E tests for the new flow
+
+**Out of scope** (deferred to the dashboard PR or beyond):
+
+- Curator-side review of the intent (Phase 1.9b dashboard PR adds the metadata display
+  and the demote-on-approve flow)
+- Curator-side promotion `training_only → public` (requires re-consent flow, not
+  shipping in v1)
+- Bulk re-consent UI for existing contributors (no production users yet, so backfilled
+  rows are inert)
+
+## Decisions Locked
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Default intent for new contributions | `training_only` | Privacy by default — contributor opts in to public catalog |
+| Existing-row backfill | `training_only` | Consistent with the new default; no production users affected |
+| Curator override capability | Demote only (`public → training_only`); no promote | Demote is a strict subset of contributor consent; promote requires re-consent |
+| Where intent is stored | `photo_contributions.intent` (immutable audit) + `item_photos.visibility` (mutable curator-controlled) | Separates "what the contributor wanted" from "what the catalog actually shows" |
+
+## Database — Migration 037
+
+```sql
+-- 037_photo_contribution_visibility.sql
+
+-- Visibility on item_photos: controls public catalog inclusion
+ALTER TABLE item_photos
+  ADD COLUMN visibility TEXT NOT NULL DEFAULT 'public'
+    CHECK (visibility IN ('public', 'training_only'));
+
+-- Intent on photo_contributions: locked-in contributor consent
+ALTER TABLE photo_contributions
+  ADD COLUMN intent TEXT NOT NULL DEFAULT 'training_only'
+    CHECK (intent IN ('training_only', 'catalog_and_training'));
+
+-- Backfill: existing item_photos rows that came via a contribution → training_only
+UPDATE item_photos ip
+  SET visibility = 'training_only'
+  FROM photo_contributions pc
+  WHERE pc.item_photo_id = ip.id;
+
+-- Backfill: existing photo_contributions rows → training_only (already the new default,
+-- but explicit for clarity)
+UPDATE photo_contributions
+  SET intent = 'training_only';
+
+-- Index for the catalog list query
+CREATE INDEX idx_item_photos_public_approved
+  ON item_photos (item_id, sort_order)
+  WHERE visibility = 'public' AND status = 'approved';
+```
+
+**Notes on the backfill:**
+
+- Direct curator uploads (no `photo_contributions` row) keep the new default `'public'`,
+  preserving existing behavior for catalog photos uploaded via the curator UI
+- All rows that came via a contribution are downgraded to `training_only`, even if
+  previously `'approved'` and visible in the catalog. This is the correct privacy default
+  per Q2; no production users exist yet so the practical impact is zero
+- The `item_photos.status` defaults stay unchanged (migration 023's `'approved'` default)
+
+## API Endpoint
+
+### `POST /collection/:id/photos/:photoId/contribute` (modified)
+
+Body gains `intent`:
+
+```typescript
+{
+  consent_version: string;
+  consent_acknowledged: boolean;
+  intent: 'training_only' | 'catalog_and_training';  // NEW, required
+}
+```
+
+**Validation:**
+
+- `intent` is **required** (no server-side default — the contributor must have made an
+  explicit choice in the UI)
+- Existing validation for `consent_acknowledged === true` and `consent_version` unchanged
+
+**Behavior:**
+
+- Stores `intent` on the new `photo_contributions` row
+- Sets `item_photos.visibility = 'training_only'` if `intent === 'training_only'`,
+  else `'public'`
+- All other contribute logic (file copy, dhash reuse, status='pending') unchanged
+
+**Response shape:** unchanged (`{ contribution_id }`).
+
+## Web UI Changes
+
+### `ContributeDialog` (web/src/collection/photos/ContributeDialog.tsx)
+
+Adds an **intent radio picker** between the photo preview and the consent checkbox:
+
+```
+┌─────────────────────────────────────┐
+│  [photo preview]                    │
+│                                     │
+│  How should this photo be used?     │
+│  ◉ Training only                    │   ← default selected
+│    Used to train the ML model.      │
+│    Not shown in the public catalog. │
+│                                     │
+│  ◯ Catalog + Training               │
+│    Visible in the public catalog    │
+│    AND used for ML training.        │
+│                                     │
+│  [licensing disclaimer callout]     │
+│                                     │
+│  ☐ I confirm I have the right…      │
+│                                     │
+│  [Cancel]   [Contribute to Catalog] │   ← button label adapts to intent
+└─────────────────────────────────────┘
+```
+
+- Default selection: `'training_only'` (privacy default)
+- Submit button label is dynamic: `"Contribute to Catalog"` when intent is
+  `catalog_and_training`, `"Contribute to Training"` when `training_only`
+- The licensing disclaimer text is **identical** for both intents (the underlying license
+  grant is the same — only the display surface differs)
+
+### `AddToCollectionDialog` (web/src/collection/components/AddToCollectionDialog.tsx)
+
+The current "Contribute this photo to the catalog" checkbox is **replaced** with a 3-state
+radio inside the Photo Options section:
+
+```
+Photo Options
+─────────────────────────────────────
+[ photo preview ] filename
+                  size
+
+☑ Save this photo to your collection item
+
+When save is checked:
+  How should this photo be shared?
+  ◉ Don't contribute              ← default
+  ◯ Training only
+  ◯ Catalog + training
+
+  [conditional inline disclaimer when not "Don't contribute"]
+```
+
+- The "Don't contribute" option replaces the current default-unchecked state
+- Selecting either contribute option expands the inline disclaimer (same text as
+  ContributeDialog's callout but condensed)
+- Submit logic in the dialog's chained mutation chain branches on the intent value
+
+## Catalog Photo List Query — Filter Update
+
+### `api/src/catalog/photos/queries.ts` — `listPhotos()`
+
+Add `AND visibility = 'public'` to the existing filter:
+
+```sql
+SELECT id, url, caption, is_primary, sort_order
+FROM item_photos
+WHERE item_id = $1
+  AND status = 'approved'
+  AND visibility = 'public'           -- NEW
+ORDER BY is_primary DESC, sort_order ASC
+```
+
+This is the only change to the public catalog query path. Training-only photos never
+appear in:
+
+- The catalog item detail page photo gallery
+- The lightbox
+- The collection page thumbnails (which COALESCE catalog primary photos)
+- The Search results
+
+They DO appear in:
+
+- The ML training data exporter (filters `status='approved'` only, no visibility filter)
+- The curator approval dashboard (Phase 1.9b — sees all pending regardless of visibility)
+- The contributor's own collection photo sheet (private, RLS-protected, unaffected)
+
+## ML Training Data Exporter Update
+
+The Phase 4.0 training data exporter currently filters `WHERE status = 'approved'`. No
+change needed to its filter — it already includes all approved photos regardless of
+visibility. **However**, the exporter must NOT add a `visibility = 'public'` filter when
+it's eventually enhanced. Add a comment to that effect in the relevant query file
+(`ml/data-prep/` or wherever the exporter lives) so future maintainers don't "tighten" it.
+
+## Test Plan
+
+| Layer | Coverage |
+|---|---|
+| API unit | Migration backfill correctness, intent validation in contribute endpoint, visibility derivation logic |
+| API integration | Contribute with `training_only` → catalog list does NOT include the photo after approval; contribute with `catalog_and_training` → catalog list DOES include after approval; backfill verification (existing pending contributions have `intent='training_only'` after migration) |
+| Web unit | `ContributeDialog` intent radio + dynamic button label; `AddToCollectionDialog` 3-state radio + chained mutation correctly passes intent |
+| E2E | Contributor selects training-only → photo never appears in catalog; contributor selects catalog+training → photo appears in catalog after approval |
+
+Test scenarios in `docs/test-scenarios/E2E_COLLECTION_PHOTOS.md` (existing file, append
+new "Contribution Intent" section).
+
+## Files Modified / Created
+
+### New
+- `api/db/migrations/037_photo_contribution_visibility.sql`
+
+### Modified
+- `api/src/collection/photos/routes.ts` — contribute endpoint accepts `intent`
+- `api/src/collection/photos/queries.ts` — `insertPendingCatalogPhoto` derives visibility
+- `api/src/collection/photos/schemas.ts` — add `intent` to ContributeBody
+- `api/src/catalog/photos/queries.ts` — `listPhotos` filters `visibility = 'public'`
+- `web/src/collection/photos/ContributeDialog.tsx` — add intent radio
+- `web/src/collection/photos/api.ts` — pass intent to contribute call
+- `web/src/collection/photos/useCollectionPhotoMutations.ts` — accept intent parameter
+- `web/src/collection/components/AddToCollectionDialog.tsx` — replace checkbox with 3-state radio
+- `web/src/lib/zod-schemas.ts` — add intent enum to contribute request schema
+- `docs/test-scenarios/E2E_COLLECTION_PHOTOS.md` — append "Contribution Intent" section
+- Existing tests for `ContributeDialog`, `AddToCollectionDialog`, contribute API
+
+## Dependencies on Other Work
+
+This amendment must ship **before** the Photo Approval Dashboard (#72), because the
+dashboard plan assumes:
+
+- `photo_contributions.intent` exists for the metadata panel display
+- `item_photos.visibility` exists for the demote-on-approve flow
+- The catalog list query already filters `visibility = 'public'`
+
+After this PR merges, the dashboard plan's migration is renumbered from 037 to 038, and
+the dashboard PR can assume the new fields are queryable.
+
+## Risks
+
+- **R1 — Backfill silently downgrades existing approved catalog photos.** Acceptable
+  because zero production users have contributed photos at this point in the project.
+  Documented in the changelog so post-launch contributors don't hit a surprise.
+- **R2 — Migration is non-reversible without a separate down migration.** Standard for
+  this codebase; the amendment doesn't introduce new precedent.
+- **R3 — The 3-state radio in `AddToCollectionDialog` is a breaking change to the prop
+  shape**. The previous `contributePhoto: boolean` becomes `contributeIntent: 'none' |
+  'training_only' | 'catalog_and_training'`. Internal-only component, no consumers
+  outside the file.
+
+## Out-of-Scope Followups
+
+- **Bulk re-consent UI for existing contributors**: not needed (no production users)
+- **Curator-side promotion UX**: requires a re-consent flow (notification to contributor,
+  pending acceptance, etc.). Not planned for v1.
+- **Per-image visibility on uploaded catalog photos**: curators uploading directly via
+  the existing curator photo flow always get `visibility='public'`. If curators want to
+  upload training-only catalog photos, that's a separate enhancement.

--- a/docs/test-scenarios/E2E_PHOTO_APPROVAL.md
+++ b/docs/test-scenarios/E2E_PHOTO_APPROVAL.md
@@ -1,0 +1,397 @@
+# E2E: Photo Approval Dashboard
+
+## Background
+
+Given the web app is running
+And the user is signed in as a curator
+And the photo approval API endpoints are available
+
+## Scenarios
+
+### Dashboard Access & Empty State
+
+```gherkin
+Scenario: Curator accesses the dashboard via the admin nav
+  Given the user is signed in as a curator
+  And there are pending photos in the queue
+  When they navigate to /admin
+  Then the "Admin" sidebar shows a "Photo Approvals" link
+  And the link displays an amber notification dot
+  When they click "Photo Approvals"
+  Then they land on /admin/photo-approvals
+  And the first pending photo is displayed in the triage view
+
+Scenario: Empty queue shows the empty state
+  Given there are no pending photos
+  When the curator navigates to /admin/photo-approvals
+  Then they see "No photos awaiting review"
+  And there is a "Back to Admin" link
+  And the notification dot on the nav is hidden
+
+Scenario: Non-curator cannot access the dashboard
+  Given the user is signed in as a regular user (not curator/admin)
+  When they navigate to /admin/photo-approvals
+  Then they are redirected to the dashboard or see an access-denied message
+```
+
+### Single-Image Triage View
+
+```gherkin
+Scenario: Triage view shows photo + metadata + existing photos
+  Given a pending photo from a contribution
+  When the curator views it in the triage view
+  Then the hero image is displayed prominently
+  And the metadata sidebar shows the item name as a link
+  And the sidebar shows the uploader's display name
+  And the sidebar shows the contribution consent version and date
+  And the sidebar shows up to 3 existing approved photos for the same item
+
+Scenario: GDPR-purged uploader is acknowledged
+  Given a pending photo whose uploader has been GDPR-deleted (uploaded_by IS NULL)
+  When the curator views it
+  Then the uploader field shows "[REDACTED — GDPR]"
+  And no other PII is displayed
+
+Scenario: Direct curator upload has no contribution metadata
+  Given a pending photo with no associated photo_contributions row
+  When the curator views it
+  Then the "Contribution" section in the sidebar is hidden or shows "Direct upload"
+```
+
+### Approval Flow (Mouse + Keyboard)
+
+```gherkin
+Scenario: Curator approves a photo via the Approve button
+  Given the curator is on the triage view
+  When they click "Approve"
+  Then a success toast appears with "Photo approved" and an "Undo" button
+  And the photo slides out left
+  And the next pending photo slides in from the right
+  And the queue position indicator updates (e.g., "2 / 12" → "3 / 12")
+
+Scenario: Curator approves a photo via keyboard shortcut A
+  Given the curator is on the triage view
+  When they press the "A" key
+  Then the same approval flow as the button click occurs
+
+Scenario: Approving the last photo shows the empty state
+  Given the queue has 1 pending photo
+  When the curator approves it
+  Then a success toast appears
+  And the empty state replaces the triage view
+```
+
+### Rejection Flow
+
+```gherkin
+Scenario: Curator rejects with no reason via R-R chord
+  Given the curator is on the triage view
+  When they press "R" twice within 500ms
+  Then a success toast appears with "Photo rejected"
+  And the photo's status is updated to 'rejected' with no rejection_reason_code
+  And the next photo loads
+
+Scenario: Single R press does NOT reject
+  Given the curator is on the triage view
+  When they press "R" once
+  And wait 1 second
+  Then no rejection occurs
+  And the photo remains in view
+
+Scenario: Curator rejects with preset reason via numeric key
+  Given the curator is on the triage view
+  When they press "1" (blurry)
+  Then a success toast appears with "Photo rejected (blurry)"
+  And the photo's rejection_reason_code is 'blurry'
+  And the next photo loads
+
+Scenario: Curator rejects with "other" reason via keyboard shortcut
+  Given the curator is on the triage view
+  When they press "6" (other)
+  Then a free-text input appears for the rejection reason
+  And keyboard shortcuts are temporarily disabled while the input is focused
+  When they type "Background is distracting" and confirm
+  Then the photo's rejection_reason_code is 'other'
+  And the rejection_reason_text is "Background is distracting"
+  And the next photo loads
+
+Scenario: Curator rejects via mouse and reason dropdown
+  Given the curator is on the triage view
+  When they click "Reject"
+  Then a reason dropdown appears with all 6 preset options
+  When they select "Wrong item"
+  Then the photo's rejection_reason_code is 'wrong_item'
+  And a success toast confirms the action
+```
+
+### Undo
+
+```gherkin
+Scenario: Curator undoes an accidental approval
+  Given the curator just approved a photo
+  And the success toast is still visible (5-second window)
+  When they click the "Undo" button on the toast
+  Then the photo's status reverts to 'pending'
+  And the photo reappears in the queue
+  And the queue position is restored
+  And the photo_contributions row (if any) also reverts to 'pending'
+
+Scenario: Undo after toast expires fails gracefully
+  Given the curator just approved a photo
+  When 6 seconds pass (toast auto-dismisses)
+  Then the undo button is no longer available
+  And there is no way to retroactively undo via the dashboard
+
+Scenario: Concurrent toasts have independent undo callbacks
+  Given the curator approves photo X
+  And immediately approves photo Y (before X's toast dismisses)
+  When they click "Undo" on Y's toast
+  Then ONLY photo Y is reverted
+  And photo X remains approved
+```
+
+### Atomic Flip Across Tables
+
+```gherkin
+Scenario: Approving a contributed photo updates both tables
+  Given a pending photo with a non-revoked photo_contributions row
+  When the curator approves it
+  Then item_photos.status is 'approved'
+  And photo_contributions.status is 'approved'
+  And both updated_at timestamps are set in the same transaction
+
+Scenario: Rejecting a direct upload only updates item_photos
+  Given a pending photo with NO photo_contributions row (direct curator upload)
+  When the curator rejects it
+  Then item_photos.status is 'rejected'
+  And no error occurs from the missing contribution row
+```
+
+### Film-Strip Queue Navigation
+
+```gherkin
+Scenario: Curator clicks a film-strip thumbnail to jump
+  Given the queue has 5 pending photos
+  And the curator is viewing photo 1
+  When they click the thumbnail for photo 4 in the film strip
+  Then photo 4 becomes the active triage view
+  And the active indicator on the film strip moves to position 4
+
+Scenario: Curator navigates with S and D keys
+  Given the curator is viewing photo 3 of 5
+  When they press "D"
+  Then photo 4 becomes active
+  When they press "S"
+  Then photo 3 becomes active again
+
+Scenario: Pressing D on the last photo wraps to first
+  Given the curator is viewing the last photo in the queue
+  When they press "D"
+  Then the first photo becomes active
+```
+
+### Notification Dot
+
+```gherkin
+Scenario: Pending count > 0 shows the notification dot
+  Given there are 3 pending photos
+  When the user navigates to any admin page
+  Then the "Photo Approvals" sidebar link shows an amber dot
+
+Scenario: Notification dot updates after a curator action
+  Given the dot is visible and the count is 3
+  When the curator approves a photo
+  Then the count refreshes to 2
+  And after approving the last 2 photos, the dot disappears
+
+Scenario: Dot does not poll
+  Given the dot is visible
+  When the curator stays on the dashboard for 2 minutes without acting
+  Then no count refresh requests are made (verified via network tab)
+```
+
+### Concurrency & Tombstoned Users
+
+```gherkin
+Scenario: Concurrent approval returns 409 and refetches the queue
+  Given two curators have the same pending photo open in their dashboards
+  When curator A approves photo X
+  And curator B then tries to approve photo X
+  Then curator B's PATCH request returns 409 with current_status='approved'
+  And curator B's UI shows "Photo state has changed — refreshing queue"
+  And curator B's queue refetches and no longer shows photo X
+
+Scenario: Tombstoned uploader displays as REDACTED
+  Given a pending photo whose uploader was GDPR-deleted (users.deleted_at IS NOT NULL)
+  When the curator views the photo
+  Then the uploader sidebar field shows "[REDACTED — GDPR]"
+  And the API response has uploader=null (not partial PII)
+
+Scenario: Photo with no existing approved photos for the same item
+  Given a pending photo for an item with zero approved photos
+  When the curator views it
+  Then the "Existing Photos" sidebar section is not rendered at all
+  And there is no empty placeholder
+
+Scenario: Revoked contribution does not appear in the queue
+  Given a user contributed a photo and then revoked it
+  When the curator opens the dashboard
+  Then the corresponding item_photos row does NOT appear in the queue
+  And the curator sees no orphaned photos
+
+Scenario: Photo with file_copied=false does not appear in the queue
+  Given a contribution row exists but file_copied is false (crash recovery state)
+  When the curator opens the dashboard
+  Then that photo is excluded from the queue
+  And the curator never sees broken images
+```
+
+### "Other" Reason Inline Input
+
+```gherkin
+Scenario: Pressing 6 opens an inline input with the curator's free text
+  Given the curator is on the triage view
+  When they press "6"
+  Then an inline text input appears below the action bar
+  And the input is auto-focused
+  And keyboard shortcuts are suppressed while the input has focus
+  When they type "Watermark in lower right"
+  And press Enter
+  Then the photo's rejection_reason_code is 'other'
+  And the rejection_reason_text is "Watermark in lower right"
+
+Scenario: Pressing Esc in the "other" input cancels the entire reject action
+  Given the curator pressed 6 and the input is open
+  When they press Esc without typing anything
+  Then the input closes
+  And the photo remains in 'pending' status
+  And the curator returns to the triage view
+
+Scenario: Empty "other" text is accepted as code='other', text=null
+  Given the curator pressed 6 and the input is open
+  When they press Enter without typing
+  Then the photo's rejection_reason_code is 'other'
+  And the rejection_reason_text is null
+
+Scenario: "Other" text exceeding 500 chars is rejected by the server
+  Given the curator types 501 characters into the "other" input
+  When they press Enter
+  Then the API returns 400 with a validation error
+  And an error toast appears
+```
+
+### Contribution Intent & Demote-on-Approve
+
+```gherkin
+Scenario: Metadata panel shows contributor intent for catalog+training photo
+  Given a pending photo whose contribution intent is 'catalog_and_training'
+  When the curator views it
+  Then the metadata sidebar shows an "Intent: Catalog + Training" badge
+  And the action bar shows BOTH "Approve" and "Approve as Training-Only" buttons
+
+Scenario: Metadata panel shows training-only intent
+  Given a pending photo whose contribution intent is 'training_only'
+  When the curator views it
+  Then the metadata sidebar shows an "Intent: Training Only" badge
+  And the action bar shows ONLY "Approve" (no demote option, since it's a no-op)
+  And the keyboard shortcut T is still bound but acts as a no-op (just approves)
+
+Scenario: Pressing A on a catalog+training photo approves with public visibility
+  Given a pending photo with intent='catalog_and_training'
+  When the curator presses "A"
+  Then the photo's status becomes 'approved'
+  And the photo's visibility remains 'public'
+  And the photo appears in the public catalog list query
+
+Scenario: Pressing T on a catalog+training photo demotes to training-only
+  Given a pending photo with intent='catalog_and_training'
+  When the curator presses "T"
+  Then the photo's status becomes 'approved'
+  And the photo's visibility becomes 'training_only'
+  And the photo does NOT appear in the public catalog list query
+  And the photo IS included in ML training data exports
+  And the photo_contributions.intent remains 'catalog_and_training' (audit unchanged)
+
+Scenario: Pressing T on a training-only photo is a no-op approve
+  Given a pending photo with intent='training_only'
+  When the curator presses "T"
+  Then the photo's status becomes 'approved'
+  And the photo's visibility remains 'training_only'
+  And no demote action occurs (it was already training-only)
+
+Scenario: API rejects promotion attempts (visibility=public)
+  Given the curator's PATCH request body includes visibility='public'
+  When the request hits the API
+  Then the server returns 422 Unprocessable Entity
+  And the error message mentions that promotion requires re-consent
+
+Scenario: Demoted photo disappears from catalog immediately
+  Given the curator just demoted photo X with the T key
+  When a regular user opens the catalog item detail page for X's item
+  Then photo X is NOT in the photo gallery
+  And only the public-visibility photos for that item are shown
+
+Scenario: Undoing a demote leaves visibility stale until next decision
+  Given the curator demoted photo X with T (intent was catalog+training)
+  When they click Undo on the Sonner toast
+  Then the photo's status reverts to 'pending'
+  And the photo's visibility STAYS at 'training_only' (undo only reverts status)
+  And the photo re-enters the queue
+
+Scenario: Re-approving with A after a demote+undo restores public visibility
+  Given the curator demoted photo X (intent='catalog+training', visibility now 'training_only')
+  And then undid the action (status back to 'pending')
+  When they press "A" on photo X
+  Then the photo's status becomes 'approved'
+  And the photo's visibility is RESTORED to 'public' (path-independent: A always
+    honors the contributor's intent regardless of prior visibility state)
+  And the photo appears in the public catalog list query
+```
+
+### Mutation In-Flight Guards
+
+```gherkin
+Scenario: Pressing A twice in rapid succession only fires one mutation
+  Given the curator is on the triage view
+  When they press "A" twice within 100ms
+  Then exactly one PATCH request is fired
+  And the second press is ignored because mutation is in flight
+
+Scenario: Modifier-held keys are ignored
+  Given the curator is on the triage view
+  When they press Cmd+R (browser refresh shortcut)
+  Then no rejection chord state is started
+  And the browser refresh proceeds normally
+
+Scenario: Keys ignored while keyboard shortcut overlay is open
+  Given the keyboard shortcut overlay is visible
+  When the curator presses "A"
+  Then the overlay does not dismiss via A and no approval fires
+  And only Esc dismisses the overlay
+```
+
+### Validation & Edge Cases
+
+```gherkin
+Scenario: Server rejects rejection_reason_text without code='other'
+  Given the curator's PATCH request includes rejection_reason_text="something" with code='blurry'
+  When the request hits the API
+  Then the server returns 400 with a validation error
+
+Scenario: Server rejects rejection_reason_code without status='rejected'
+  Given the curator's PATCH request includes status='approved' with code='blurry'
+  When the request hits the API
+  Then the server returns 400 with a validation error
+
+Scenario: Queue exceeds 200 — UI shows warning
+  Given there are 250 pending photos
+  When the curator opens the dashboard
+  Then the API returns the first 200 with total_count=250
+  And the UI displays a banner warning about the truncated queue
+
+Scenario: Keyboard shortcuts are ignored when typing in the "other" reason input
+  Given the rejection reason input is focused
+  When the curator presses "A"
+  Then the letter "a" is typed into the input
+  And no approve action fires
+```

--- a/docs/test-scenarios/README.md
+++ b/docs/test-scenarios/README.md
@@ -46,6 +46,7 @@ See [TESTING_SCENARIOS.md](../guides/TESTING_SCENARIOS.md) for the scenario-driv
 | [E2E_ML_PHOTO_IDENTIFICATION.md](E2E_ML_PHOTO_IDENTIFICATION.md)   | `web/e2e/add-by-photo.spec.ts`, `web/e2e/admin-ml-stats.spec.ts`                                                                                              | ✅ Implemented                          |
 | [INT_COLLECTION_PHOTOS.md](INT_COLLECTION_PHOTOS.md)               | `api/src/collection/photos/routes.test.ts`                                                                                                                    | ✅ Implemented                          |
 | [E2E_COLLECTION_PHOTOS.md](E2E_COLLECTION_PHOTOS.md)               | `web/e2e/collection-photos.spec.ts`                                                                                                                           | Scenarios written                       |
+| [E2E_PHOTO_APPROVAL.md](E2E_PHOTO_APPROVAL.md)                     | `web/e2e/photo-approval.spec.ts` (planned)                                                                                                                    | Scenarios written                       |
 
 ## Creating a New Scenario
 


### PR DESCRIPTION
## Summary
Two interlinked design documents for #72 (Phase 1.9b approval dashboard) and a Phase 1.6 amendment that must ship first.

- **\`docs/plans/Photo_Contribution_Visibility_Plan.md\` (NEW)**: adds \`visibility\` (\`'public' | 'training_only'\`) to \`item_photos\` and \`intent\` (\`'training_only' | 'catalog_and_training'\`) to \`photo_contributions\`. Locked decisions: \`training_only\` as the privacy default for both new contributions and existing-row backfill; **demote-only** curator override (no promotion without re-consent); separate amendment PR before #72.
- **\`docs/plans/Photo_Approval_Dashboard_Plan.md\` (NEW)**: single-image triage UI with left-hand keyboard shortcuts (\`A\` approve as-intended, \`T\` approve as training-only / demote, \`R-R\` reject chord, \`1-6\` reject reasons), film-strip queue, undo-last via Sonner, optimistic concurrency via \`expected_status\`, atomic flip across \`item_photos\` + \`photo_contributions\`. Migration 038 (renumbered to follow the visibility amendment).
- **\`docs/test-scenarios/E2E_PHOTO_APPROVAL.md\` (NEW)**: Gherkin scenarios across dashboard access, triage, approval/rejection, undo, concurrency, contribution intent, demote-on-approve, and edge cases.
- **\`docs/plans/Development_Roadmap_v1_0.md\`**: link #72 to both plan docs.
- **\`docs/test-scenarios/README.md\`**: register the new scenarios file.

## Architecture Audit
The architecture has been audited via 10 sequential review passes from fresh perspectives. All 18 medium-severity findings were resolved before doc finalization, including:
- Atomic flip WHERE clause (\`status != 'revoked'\` not \`= 'pending'\`)
- Optimistic concurrency via \`expected_status\` field + 409 handling
- Tombstoned uploader handling in the query JOIN
- Keyboard handler guards (modifier-held, input/textarea, in-flight, overlay-open)
- Path-independent visibility semantics on approve actions
- All Zod schemas specified

## Next Steps
This is a docs-only PR. After merge:
1. Implement the Phase 1.6 amendment (Photo_Contribution_Visibility_Plan.md) as a new PR
2. Implement the Photo Approval Dashboard (#72) as a follow-up PR

Refs #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)